### PR TITLE
Network [#60] CombineMoya 를 활용한 네트워크 통신

### DIFF
--- a/Wable-iOS/Global/Extention/Publisher+UIControl.swift
+++ b/Wable-iOS/Global/Extention/Publisher+UIControl.swift
@@ -67,3 +67,13 @@ struct UIControlPublisher<Control: UIControl>: Publisher {
         subscriber.receive(subscription: subscription)
     }
 }
+
+extension Publisher {
+    /// 네트워크 통신 후 뷰 모델에서 에러를 단순히 출력할 때 사용합니다.
+    func mapWableNetworkError() -> Publishers.MapError<Self, Failure> where Failure == BaseAPI.WableNetworkError {
+        self.mapError { error in
+            Swift.print("\(error)")
+            return error
+        }
+    }
+}

--- a/Wable-iOS/Network/Foundation/URLSession/Empty.swift
+++ b/Wable-iOS/Network/Foundation/URLSession/Empty.swift
@@ -14,3 +14,5 @@ struct EmptyBody: Encodable {
 struct EmptyResponse: Decodable {
     
 }
+
+struct EmptyDTO: Codable {}

--- a/Wable-iOS/Network/Info/InfoAPI.swift
+++ b/Wable-iOS/Network/Info/InfoAPI.swift
@@ -6,22 +6,24 @@
 //
 
 import Foundation
+import Combine
 
+import CombineMoya
 import Moya
 
 final class InfoAPI: BaseAPI {
     static let shared =  InfoAPI()
-        private var infoProvider = MoyaProvider<InfoRouter>(plugins: [MoyaLoggingPlugin()])
-        private override init() {}
+    private var infoProvider = MoyaProvider<InfoRouter>(plugins: [MoyaLoggingPlugin()])
+    private override init() {}
 }
 
 extension InfoAPI {
-    func getMatchInfo(completion: @escaping (NetworkResult<Any>) -> Void) {
-        infoProvider.request(.getMatchInfo) { result in
-            self.disposeNetwork(result,
-                                dataModel: [TodayMatchesDTO].self,
-                                completion: completion)
-            
-        }
+    func getMatchInfo() -> AnyPublisher<[TodayMatchesDTO]?, WableNetworkError> {
+        infoProvider.requestPublisher(.getMatchInfo)
+            .tryMap { [weak self] response -> [TodayMatchesDTO]? in
+                return try self?.parseResponse(statusCode: response.statusCode, data: response.data)
+            }
+            .mapError { $0 as? WableNetworkError ?? .unknownError($0.localizedDescription) }
+            .eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 🛠️ PR POINT
<!-- `작업한 내용을 적어주세요. -->
- CombineMoya를 이용하여 방출되는 Moya의 requestPublisher를 가공하여 네트워크 통신에 사용합니다.

### WableNetworkError
- 네트워크에 따른 에러 방출과 분기 처리를 위해 새로운 에러 타입을 정의하였습니다.
- 프린트 시, 보다 간편하게 사용하기 위해 CustomStringConvertible을 채택하였습니다.

### BaseAPI의 parseResponse 메서드 사용
- 기존의 BaseResponse를 활용하였습니다.
- **만약 서버 명세에 응답에 데이터가 없다면, 네트워크 통신 시 EmptyDTO를 사용합니다.**
- `tryMap`에서 `parseResponse`를 호출하여, 디코딩과 에러 매핑을 합니다.
- `mapError`에서 매핑 되지 않은 에러에 대해 `unknownError`로 대응합니다.

<details>
<summary>InfoAPI</summary>

```swift
extension InfoAPI {
    func getMatchInfo() -> AnyPublisher<[TodayMatchesDTO]?, WableNetworkError> {
        infoProvider.requestPublisher(.getMatchInfo)
            .tryMap { [weak self] response -> [TodayMatchesDTO]? in
                return try self?.parseResponse(statusCode: response.statusCode, data: response.data)
            }
            .mapError { $0 as? WableNetworkError ?? .unknownError($0.localizedDescription) }
            .eraseToAnyPublisher()
    }
}
```
</details>

### ViewModel에서 네트워크 수신
- `flatMap`을 통해 특정 신호로부터 네트워크를 통해 전달된 퍼블리셔로 변환합니다.
- `mapWableNetworkError`는 현재 특별하게 에러처리를 하고 있지 않기 때문에, 단순히 콘솔에 출력되도록 만든 커스텀 연산자입니다.
- `replaceError`를 통해 에러 발생 시, 다른 값으로 대체 합니다. (필수!)

<details>
<summary>InfoMatchViewModel</summary>

```swift
let matchInfo = input.viewWillAppear
        .flatMap { _ -> AnyPublisher<[TodayMatchesDTO], Never> in
            return InfoAPI.shared.getMatchInfo()
                .compactMap { $0 }
                .mapWableNetworkError()
                .replaceError(with: [])
                .eraseToAnyPublisher()
        }
        .eraseToAnyPublisher()
```
</details>

## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
> 자세한 코드 설명과 동작 방식은 추후 회의 때 설명드리겠습니다.
> 그럼에도 현재의 코드에서 질문이나 수정사항 남겨주시면 감사하겠습니다.

## 📟 관련 이슈
- Resolved: #60
