### PR TITLE
Fix [#77] 소식 탭 QA 반영 및 경기 정보 뷰 수정

### DIFF
--- a/Wable-iOS.xcodeproj/project.pbxproj
+++ b/Wable-iOS.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		DEAD9CBD2CF2618F00D5CD11 /* SessionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAD9CBC2CF2618F00D5CD11 /* SessionCell.swift */; };
 		DEAD9CBF2CF2644600D5CD11 /* RankHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAD9CBE2CF2644600D5CD11 /* RankHeaderView.swift */; };
 		DEB5793A2CE3541300BEE54D /* CombineCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = DEB579392CE3541300BEE54D /* CombineCocoa */; };
+		DECF4CDB2CF6DE5F00EE78B4 /* TodayMatchesDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECF4CDA2CF6DE5F00EE78B4 /* TodayMatchesDateFormatter.swift */; };
 		DEF0D39F2CED68DE002FA608 /* WableSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF0D39E2CED68DE002FA608 /* WableSegmentedControl.swift */; };
 /* End PBXBuildFile section */
 
@@ -426,6 +427,7 @@
 		DE9D0E4C2CF0C9250024BB1F /* TeamImageMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamImageMapper.swift; sourceTree = "<group>"; };
 		DEAD9CBC2CF2618F00D5CD11 /* SessionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCell.swift; sourceTree = "<group>"; };
 		DEAD9CBE2CF2644600D5CD11 /* RankHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankHeaderView.swift; sourceTree = "<group>"; };
+		DECF4CDA2CF6DE5F00EE78B4 /* TodayMatchesDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayMatchesDateFormatter.swift; sourceTree = "<group>"; };
 		DEF0D39E2CED68DE002FA608 /* WableSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WableSegmentedControl.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1445,6 +1447,7 @@
 			isa = PBXGroup;
 			children = (
 				050E0CE92C74DC4B00326EEA /* MatchProgress.swift */,
+				DECF4CDA2CF6DE5F00EE78B4 /* TodayMatchesDateFormatter.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -1713,6 +1716,7 @@
 				0547F4FF2C64C954001E3039 /* ExampleViewController.swift in Sources */,
 				3CF344D02C749A120038BB53 /* MyPageBottomSheetView.swift in Sources */,
 				3C8B4E3D2C79119F00174943 /* MyPageMemberCommentResponseDTO.swift in Sources */,
+				DECF4CDB2CF6DE5F00EE78B4 /* TodayMatchesDateFormatter.swift in Sources */,
 				050E0CBB2C74B89300326EEA /* FeedInfoView.swift in Sources */,
 				3C8B4E162C78E20F00174943 /* SocialLoginRequestDTO.swift in Sources */,
 				0593F6D62C96D6C100FFAD82 /* WablePhotoDetailView.swift in Sources */,

--- a/Wable-iOS/Network/Info/ResponseDTO/TodayMatchesDTO.swift
+++ b/Wable-iOS/Network/Info/ResponseDTO/TodayMatchesDTO.swift
@@ -10,51 +10,17 @@ import Foundation
 // MARK: - TodayMatchesDTO
 
 struct TodayMatchesDTO: Codable {
-    private(set) var date: String
-    private(set) var games: [Game]
-    
-    mutating func formatDate() {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd" // 서버에서 받은 date 형식
-        dateFormatter.locale = Locale(identifier: "ko_KR") // 포맷 일관성을 위해 사용
-        
-        if let dateObject = dateFormatter.date(from: date) {
-            // 변환할 새로운 포맷 지정
-            dateFormatter.dateFormat = "MM.dd (EEE)" // "월.일 (요일)" 형식
-            self.date = dateFormatter.string(from: dateObject) // date 문자열을 변환된 포맷으로 업데이트
-            print("\(dateFormatter.string(from: dateObject))")
-        } else {
-            print("망했지예~")
-        }
-        
-        // games 배열 내 각 게임의 시간 형식 변환
-        for i in 0..<games.count {
-            games[i].formatGameTime()
-        }
-    }
+    let date: String
+    let games: [Game]
 }
 
 // MARK: - Game
 
 struct Game: Codable, Hashable {
-    private(set) var gameDate: String
+    let gameDate: String
     let aTeamName: String
     let aTeamScore: Int
     let bTeamName: String
     let bTeamScore: Int
     let gameStatus: String
-    
-    mutating func formatGameTime() {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm" // 서버에서 받은 gameDate 형식
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX") // 포맷 일관성을 위해 사용
-        
-        if let dateObject = dateFormatter.date(from: gameDate) {
-            // 변환할 새로운 포맷 지정
-            dateFormatter.dateFormat = "HH:mm" // "시간:분" 형식
-            self.gameDate = dateFormatter.string(from: dateObject) // gameDate 문자열을 변환된 포맷으로 업데이트
-        } else {
-            print("^^~")
-        }
-    }
 }

--- a/Wable-iOS/Presentation/Info/Detail/View/InfoDetailView.swift
+++ b/Wable-iOS/Presentation/Info/Detail/View/InfoDetailView.swift
@@ -36,6 +36,7 @@ final class InfoDetailView: UIView {
         let label = UILabel()
         label.textColor = .wableBlack
         label.font = .head1
+        label.numberOfLines = 0
         return label
     }()
     
@@ -108,6 +109,8 @@ final class InfoDetailView: UIView {
     }
 }
 
+// MARK: - Private Method
+
 private extension InfoDetailView {
     func setupView() {
         backgroundColor = .wableWhite
@@ -146,11 +149,15 @@ private extension InfoDetailView {
         titleLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(18)
             make.leading.equalToSuperview().offset(16)
+            make.trailing.equalTo(timeLabel.snp.leading).offset(-4)
         }
         
+        titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        
         timeLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel).offset(4)
             make.trailing.equalToSuperview().offset(-16)
-            make.centerY.equalTo(titleLabel)
+            make.width.equalTo(52.adjusted)
         }
         
         imageView.snp.makeConstraints { make in

--- a/Wable-iOS/Presentation/Info/Detail/ViewController/ImagePopupViewController.swift
+++ b/Wable-iOS/Presentation/Info/Detail/ViewController/ImagePopupViewController.swift
@@ -63,7 +63,7 @@ private extension ImagePopupViewController {
         
         var height = UIScreen.main.bounds.width * aspectRatio
         
-        let maxHeight: CGFloat = 450
+        let maxHeight: CGFloat = 812
         
         if height > maxHeight {
             height = maxHeight
@@ -76,8 +76,9 @@ private extension ImagePopupViewController {
         }
         
         dismissButton.snp.makeConstraints { make in
-            make.top.trailing.equalTo(imageView).inset(8)
-            make.size.equalTo(44.adjusted)
+            make.size.equalTo(60.adjusted)
+            make.centerX.equalToSuperview()
+            make.bottom.equalToSuperview().offset(-100)
         }
     }
     

--- a/Wable-iOS/Presentation/Info/Match/Support/TodayMatchesDateFormatter.swift
+++ b/Wable-iOS/Presentation/Info/Match/Support/TodayMatchesDateFormatter.swift
@@ -1,0 +1,81 @@
+//
+//  TodayMatchesDateFormatter.swift
+//  Wable-iOS
+//
+//  Created by 김진웅 on 11/27/24.
+//
+
+import Foundation
+
+struct TodayMatchesDateFormmatter {
+    private let inputFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+        return dateFormatter
+    }()
+    
+    private let outputFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MM.dd (EEE)"
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+        return dateFormatter
+    }()
+    
+    private let gameFormatter = GameDateFormatter()
+    
+    func formatting(_ matches: [TodayMatchesDTO]) -> [TodayMatchesDTO] {
+        matches.map { formatting($0) }
+    }
+    
+    func formatting(_ match: TodayMatchesDTO) -> TodayMatchesDTO {
+        TodayMatchesDTO(
+            date: monthAndDay(match.date),
+            games: gameFormatter.formatting(match.games)
+        )
+    }
+    
+    private func monthAndDay(_ dateString: String) -> String {
+        guard let date = inputFormatter.date(from: dateString) else {
+            return dateString
+        }
+        return outputFormatter.string(from: date)
+    }
+}
+
+struct GameDateFormatter {
+    private let inputFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        return dateFormatter
+    }()
+    
+    private let outputFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "HH:mm"
+        return dateFormatter
+    }()
+    
+    func formatting(_ games: [Game]) -> [Game] {
+        games.map { formatting($0) }
+    }
+    
+    func formatting(_ game: Game) -> Game {
+        Game(
+            gameDate: hourAndMinute(game.gameDate),
+            aTeamName: game.aTeamName,
+            aTeamScore: game.aTeamScore,
+            bTeamName: game.bTeamName,
+            bTeamScore: game.bTeamScore,
+            gameStatus: game.gameStatus
+        )
+    }
+    
+    private func hourAndMinute(_ dateString: String) -> String {
+        guard let date = inputFormatter.date(from: dateString) else {
+            return dateString
+        }
+        return outputFormatter.string(from: date)
+    }
+}

--- a/Wable-iOS/Presentation/Info/Match/View/Cell/MatchSessionTableViewCell.swift
+++ b/Wable-iOS/Presentation/Info/Match/View/Cell/MatchSessionTableViewCell.swift
@@ -18,8 +18,8 @@ final class MatchSessionTableViewCell: UITableViewCell {
         return view
     }()
     
-    private let sessionLabel: UILabel = {
-       let label = UILabel()
+    let sessionLabel: UILabel = {
+        let label = UILabel()
         label.text = StringLiterals.Info.lckSummer
         label.font = .body3
         label.textColor = .purple100
@@ -36,7 +36,7 @@ final class MatchSessionTableViewCell: UITableViewCell {
         setupView()
         setupConstraints()
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -52,7 +52,7 @@ private extension MatchSessionTableViewCell {
     
     func setupConstraints() {
         sessionView.snp.makeConstraints {
-            $0.height.equalTo(39.adjusted)
+            $0.height.equalTo(40.adjustedH)
             $0.leading.trailing.equalToSuperview().inset(16.adjusted)
             $0.centerY.equalToSuperview()
         }

--- a/Wable-iOS/Presentation/Info/Match/ViewModel/InfoMatchViewModel.swift
+++ b/Wable-iOS/Presentation/Info/Match/ViewModel/InfoMatchViewModel.swift
@@ -8,27 +8,62 @@
 import Foundation
 import Combine
 
-final class InfoMatchViewModel: ViewModelType {
+final class InfoMatchViewModel {
+    private let service: InfoAPI
+    private let matchesDateFormatter = TodayMatchesDateFormmatter()
+    
+    init(service: InfoAPI = .shared) {
+        self.service = service
+    }
+}
+
+extension InfoMatchViewModel: ViewModelType {
     struct Input {
         let viewWillAppear: AnyPublisher<Void, Never>
     }
     
     struct Output {
+        let gameType: AnyPublisher<LCKGameTypeDTO, Never>
         let matchInfo: AnyPublisher<[TodayMatchesDTO], Never>
     }
     
     func transform(from input: Input, cancelBag: CancelBag) -> Output {
         let matchInfo = input.viewWillAppear
-            .flatMap { _ -> AnyPublisher<[TodayMatchesDTO], Never> in
-                return InfoAPI.shared.getMatchInfo()
-                    .compactMap { $0 }
+            .flatMap { [weak self] _ -> AnyPublisher<[TodayMatchesDTO], Never> in
+                guard let self else {
+                    return Just([]).eraseToAnyPublisher()
+                }
+                return service.getMatchInfo()
                     .mapWableNetworkError()
                     .replaceError(with: [])
+                    .compactMap { $0 }
                     .eraseToAnyPublisher()
+            }
+            .compactMap { [weak self] in
+                self?.matchesDateFormatter.formatting($0)
             }
             .eraseToAnyPublisher()
         
-        return Output(matchInfo: matchInfo)
+        let gameType = input.viewWillAppear
+            .flatMap { [weak self] _ -> AnyPublisher<LCKGameTypeDTO?, Never> in
+                guard let self else {
+                    return Just(nil).eraseToAnyPublisher()
+                }
+                
+                return service.getGameType()
+                    .mapWableNetworkError()
+                    .replaceError(with: nil)
+                    .compactMap { $0 }
+                    .eraseToAnyPublisher()
+            }
+            .compactMap { $0 }
+            .removeDuplicates(by: { $0.lckGameType == $1.lckGameType })
+            .eraseToAnyPublisher()
+        
+        return Output(
+            gameType: gameType,
+            matchInfo: matchInfo
+        )
     }
 }
 

--- a/Wable-iOS/Presentation/Info/Page/ViewController/InfoViewController.swift
+++ b/Wable-iOS/Presentation/Info/Page/ViewController/InfoViewController.swift
@@ -174,9 +174,16 @@ private extension InfoViewController {
         let selectedIndex = sender.selectedSegmentIndex
         let direction: UIPageViewController.NavigationDirection = selectedIndex > currentIndex ? .forward : .reverse
         
-        pageViewController.setViewControllers([viewControllers[selectedIndex]], direction: direction, animated: true)
-        currentIndex = selectedIndex
-        trackPageChangeEvent(for: currentIndex)
+        pageViewController.setViewControllers(
+            [viewControllers[selectedIndex]],
+            direction: direction,
+            animated: true
+        ) { [weak self] isCompleted in
+            guard isCompleted else { return }
+            
+            self?.currentIndex = selectedIndex
+            self?.trackPageChangeEvent(for: selectedIndex)
+        }
     }
     
     func updateSegmentedControl() {


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 🛠️ PR POINT
<!-- `작업한 내용을 적어주세요. -->
- 세그먼트 컨트롤과 페이지 뷰컨트롤러의 전환 간의 발생하는 런타임 에러 수정
- 경기 정보 뷰 정상화
- 상세보기 뷰 제목 줄바꿈
- 이미지 상세보기 뷰 닫기 버튼 위치 수정

### 세그먼트 컨트롤에 따른 페이지 뷰컨트롤러의 화면 전환
- 기존에는 세그먼트에 의한 페이징이 별개로 동작하였습니다.
- 하지만 비동기로 동작할 수 있는 사용자의 이벤트에 따라 해당되는 내용을 컴플리션 핸들러에서 수행해야 하지 않나 라는 생각이 들어 코드를 수정했습니다.
- 하지만 어디까지나 추측에 기반한 내용일 뿐, 확실히 런타임 에러가 나지 않는다고 말할 수는 없을 것 같습니다.

<details>
<summary>InfoViewController 코드</summary>

```swift
// 완료 여부와 상관없이 동작하는 기존의 코드
pageViewController.setViewControllers([viewControllers[selectedIndex]], direction: direction, animated: true)
currentIndex = selectedIndex
trackPageChangeEvent(for: currentIndex)
```

```swift
pageViewController.setViewControllers(
    [viewControllers[selectedIndex]],
    direction: direction,
    animated: true
) { [weak self] isCompleted in // 컴플리션 핸들러 안에서 실행되도록 수정
    guard isCompleted else { return }
    
    self?.currentIndex = selectedIndex
    self?.trackPageChangeEvent(for: selectedIndex)
}
```
</details>

## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
> 가급적 제 브랜치에서 실기기 시뮬로 런타임 에러 테스트를 부탁드리겠습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|경기 정보 뷰 정상화|<img src = "https://github.com/user-attachments/assets/372f2842-bbe4-4036-9a6d-a7f1621fa874" width ="250">|
|이미지 상세보기 닫기 버튼 위치 수정|<img src = "https://github.com/user-attachments/assets/936572f9-43cb-4e00-9d17-c8d16528190c" width ="250">|
|경기 정보 뷰 정상화|<img src = "https://github.com/user-attachments/assets/774283a4-ebdd-48f1-95de-9c16c399e7ac" width ="250">|


## 📟 관련 이슈
- Resolved: #77
