### PR TITLE
[Fix] EventMonitor의 저장 프로퍼티 관련 경고 해결

### DIFF
--- a/Wable-iOS/Infra/Network/OAuth/OAuthErrorMonitor.swift
+++ b/Wable-iOS/Infra/Network/OAuth/OAuthErrorMonitor.swift
@@ -12,15 +12,15 @@ import Alamofire
 
 final class OAuthErrorMonitor: EventMonitor {
     let queue = DispatchQueue(label: "OAuthErrorMonitorQueue", attributes: .concurrent)
-    private var condition: Bool = false
-    
+    private static var condition = false
+ 
     var isUnauthorized: Bool {
         get {
-            queue.sync { condition }
+            queue.sync { OAuthErrorMonitor.condition }
         }
         set {
             queue.async(flags: .barrier) {
-                self.condition = newValue
+                OAuthErrorMonitor.condition = newValue
             }
         }
     }

--- a/Wable-iOS/Infra/Network/OAuth/OAuthErrorMonitor.swift
+++ b/Wable-iOS/Infra/Network/OAuth/OAuthErrorMonitor.swift
@@ -16,11 +16,11 @@ final class OAuthErrorMonitor: EventMonitor {
  
     var isUnauthorized: Bool {
         get {
-            queue.sync { OAuthErrorMonitor.condition }
+            queue.sync { Self.condition }
         }
         set {
             queue.async(flags: .barrier) {
-                OAuthErrorMonitor.condition = newValue
+                Self.condition = newValue
             }
         }
     }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- `OAuthErrorMonitor` 구현 시 선언한 저장 프로퍼티로 인해 발생한 경고를 해결했어요.

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### `EventMonitor`의 `condition` 속성 변경
```swift
final class OAuthErrorMonitor: EventMonitor {
    let queue = DispatchQueue(label: "OAuthErrorMonitorQueue", attributes: .concurrent)
    private static var condition = false
 
    var isUnauthorized: Bool {
        get {
            queue.sync { OAuthErrorMonitor.condition }
        }
        set {
            queue.async(flags: .barrier) {
                OAuthErrorMonitor.condition = newValue
            }
        }
    }
 
...
```
- 원래 저장 프로퍼티 형식으로 선언되어 있던 `condition`을 정적 프로퍼티로 변경했습니다.
  - 이 방식은 경고를 해결하긴 하지만 여러 `OAuthErrorMonitor` 인스턴스가 있는 경우 모두 동일한 상태를 공유하고 한 인스턴스에서 인증 실패를 감지하면 모든 인스턴스에 영향을 미칠 수 있다는 단점이 있는데요.
  - `OAuthErrorMonitor`는 결국 앱에서 하나의 인스턴스만 선언되어야 하기 때문에 변경 가능하다는 결론을 내렸습니다.

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 자고싶어요

## 🔗 연결된 이슈
- Resolved: #106 
