### PR TITLE
[Feat] 소셜 로그인 및 자동 로그인 기능 구현

### DIFF
--- a/Wable-iOS.xcodeproj/project.pbxproj
+++ b/Wable-iOS.xcodeproj/project.pbxproj
@@ -137,6 +137,8 @@
 		DD2968792D6DAE3500143851 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DD2968772D6DAE2200143851 /* GoogleService-Info.plist */; };
 		DD29687C2D6DB27F00143851 /* OAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD29687B2D6DB27200143851 /* OAuthenticator.swift */; };
 		DD29687E2D6DC70700143851 /* OAuthCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD29687D2D6DC70100143851 /* OAuthCredential.swift */; };
+		DD4AFD452D8FF19F00D56B94 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4AFD442D8FF19B00D56B94 /* LoginViewModel.swift */; };
+		DD4AFD472D90264500D56B94 /* OAuthEventManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4AFD462D90263400D56B94 /* OAuthEventManager.swift */; };
 		DD514D082D8C83560095021D /* AgreementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD514D072D8C833D0095021D /* AgreementViewController.swift */; };
 		DD514D0A2D8C958B0095021D /* AgreementItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD514D092D8C957E0095021D /* AgreementItemView.swift */; };
 		DD514D0E2D8C99DC0095021D /* AgreementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD514D0D2D8C99DC0095021D /* AgreementView.swift */; };
@@ -355,6 +357,8 @@
 		DD29687A2D6DAE8E00143851 /* Wable-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Wable-iOS.entitlements"; sourceTree = "<group>"; };
 		DD29687B2D6DB27200143851 /* OAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthenticator.swift; sourceTree = "<group>"; };
 		DD29687D2D6DC70100143851 /* OAuthCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthCredential.swift; sourceTree = "<group>"; };
+		DD4AFD442D8FF19B00D56B94 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
+		DD4AFD462D90263400D56B94 /* OAuthEventManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthEventManager.swift; sourceTree = "<group>"; };
 		DD514D072D8C833D0095021D /* AgreementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgreementViewController.swift; sourceTree = "<group>"; };
 		DD514D092D8C957E0095021D /* AgreementItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgreementItemView.swift; sourceTree = "<group>"; };
 		DD514D0D2D8C99DC0095021D /* AgreementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgreementView.swift; sourceTree = "<group>"; };
@@ -957,6 +961,7 @@
 		DD765D982D8746D30029A317 /* Login */ = {
 			isa = PBXGroup;
 			children = (
+				DD4AFD442D8FF19B00D56B94 /* LoginViewModel.swift */,
 				DD765D992D8746DD0029A317 /* LoginViewController.swift */,
 			);
 			path = Login;
@@ -973,6 +978,7 @@
 		DD87931D2D70452B001212AE /* OAuth */ = {
 			isa = PBXGroup;
 			children = (
+				DD4AFD462D90263400D56B94 /* OAuthEventManager.swift */,
 				DD29687D2D6DC70100143851 /* OAuthCredential.swift */,
 				DD87931B2D7044E0001212AE /* OAuthErrorMonitor.swift */,
 				DD69C58F2D71A3B6000A3349 /* OAuthTokenProvider.swift */,
@@ -1571,6 +1577,7 @@
 				DD29683A2D6DAD1700143851 /* NotificationRepositoryImpl.swift in Sources */,
 				DDCD66E32D7DB11D00EF4C28 /* TabBarController.swift in Sources */,
 				DD2967F92D6DAC4800143851 /* AnyPublisher+.swift in Sources */,
+				DD4AFD452D8FF19F00D56B94 /* LoginViewModel.swift in Sources */,
 				DD2967FA2D6DAC4800143851 /* Publisher+.swift in Sources */,
 				DE7C53122D761EA400076E5D /* UIStackView+.swift in Sources */,
 				DDCCA3952D73928900658122 /* UserSession.swift in Sources */,
@@ -1593,6 +1600,7 @@
 				DD2968172D6DAD0200143851 /* ContentRepository.swift in Sources */,
 				DDED595E2D78C3E000A0BEF1 /* KakaoAuthProvider.swift in Sources */,
 				DD2968182D6DAD0200143851 /* CommunityRepository.swift in Sources */,
+				DD4AFD472D90264500D56B94 /* OAuthEventManager.swift in Sources */,
 				DDED59862D7965E900A0BEF1 /* OverviewUseCase.swift in Sources */,
 				DDED597C2D794F0D00A0BEF1 /* FetchUserAuthUseCase.swift in Sources */,
 				DE7C53102D761E3300076E5D /* String+.swift in Sources */,

--- a/Wable-iOS.xcodeproj/project.pbxproj
+++ b/Wable-iOS.xcodeproj/project.pbxproj
@@ -147,7 +147,6 @@
 		DD69C5902D71A3BE000A3349 /* OAuthTokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD69C58F2D71A3B6000A3349 /* OAuthTokenProvider.swift */; };
 		DD765D9A2D8746E30029A317 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD765D992D8746DD0029A317 /* LoginViewController.swift */; };
 		DD765D9D2D8747950029A317 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD765D9C2D8747900029A317 /* SplashViewController.swift */; };
-		DD87931C2D7044E7001212AE /* OAuthErrorMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD87931B2D7044E0001212AE /* OAuthErrorMonitor.swift */; };
 		DD9980DB2D834CA900EBBFBC /* CommentInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9980DA2D834CA900EBBFBC /* CommentInfo.swift */; };
 		DD9980DF2D834F4E00EBBFBC /* CommentCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9980DC2D834F4E00EBBFBC /* CommentCollectionViewCell.swift */; };
 		DD9980E02D834F4E00EBBFBC /* PostUserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9980DE2D834F4E00EBBFBC /* PostUserInfoView.swift */; };
@@ -367,7 +366,6 @@
 		DD69C58F2D71A3B6000A3349 /* OAuthTokenProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenProvider.swift; sourceTree = "<group>"; };
 		DD765D992D8746DD0029A317 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		DD765D9C2D8747900029A317 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
-		DD87931B2D7044E0001212AE /* OAuthErrorMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthErrorMonitor.swift; sourceTree = "<group>"; };
 		DD8CEF3D2D6A007900DBE580 /* Share.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Share.xcconfig; sourceTree = "<group>"; };
 		DD8CEF3E2D6A007900DBE580 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		DD8CEF3F2D6A007900DBE580 /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
@@ -980,7 +978,6 @@
 			children = (
 				DD4AFD462D90263400D56B94 /* OAuthEventManager.swift */,
 				DD29687D2D6DC70100143851 /* OAuthCredential.swift */,
-				DD87931B2D7044E0001212AE /* OAuthErrorMonitor.swift */,
 				DD69C58F2D71A3B6000A3349 /* OAuthTokenProvider.swift */,
 				DD29687B2D6DB27200143851 /* OAuthenticator.swift */,
 			);
@@ -1529,7 +1526,6 @@
 				DD2968462D6DAD2F00143851 /* FetchAccountInfo.swift in Sources */,
 				DD2968472D6DAD2F00143851 /* FetchContent.swift in Sources */,
 				DD2968482D6DAD2F00143851 /* FetchNotificationNumber.swift in Sources */,
-				DD87931C2D7044E7001212AE /* OAuthErrorMonitor.swift in Sources */,
 				DD2968492D6DAD2F00143851 /* FetchContents.swift in Sources */,
 				DD29684A2D6DAD2F00143851 /* FetchLCKTeamRankings.swift in Sources */,
 				DEDC29162D72099C0073D512 /* InfoNotificationType.swift in Sources */,

--- a/Wable-iOS/App/SceneDelegate.swift
+++ b/Wable-iOS/App/SceneDelegate.swift
@@ -67,11 +67,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // MARK: - Kakao URLContexts
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        if let url = URLContexts.first?.url {
-            if (AuthApi.isKakaoTalkLoginUrl(url)) {
-                _ = AuthController.handleOpenUrl(url: url)
-            }
+        guard let url = URLContexts.first?.url,
+              AuthApi.isKakaoTalkLoginUrl(url)
+        else {
+            return
         }
+        
+        _ = AuthController.handleOpenUrl(url: url)
     }
 }
 

--- a/Wable-iOS/Core/Bundle/Bundle+.swift
+++ b/Wable-iOS/Core/Bundle/Bundle+.swift
@@ -8,6 +8,14 @@
 import Foundation
 
 extension Bundle {
+    static let identifier: String = {
+        guard let identifierString = main.bundleIdentifier else {
+            fatalError("Bundle identifier를 찾을 수 없습니다.")
+        }
+        
+        return identifierString
+    }()
+    
     static let baseURL: URL = {
         guard let urlString = main.object(forInfoDictionaryKey: "BASE_URL") as? String,
               let url = URL(string: urlString)

--- a/Wable-iOS/Core/Logger/WableLogger.swift
+++ b/Wable-iOS/Core/Logger/WableLogger.swift
@@ -20,7 +20,7 @@ enum WableLogger {
     ) {
         let fileName = ((file as NSString).lastPathComponent as NSString)
             .deletingPathExtension
-        let formattedMessage = "[\(type.rawValue)/\(fileName)] \(function)-\(line); \(message)"
+        let formattedMessage = "[\(type.rawValue)/\(fileName)] \(line) line in \(function) ; \(message)"
         logger.debug("\(formattedMessage, privacy: .public)")
     }
 }

--- a/Wable-iOS/Data/RepositoryImpl/UserSessionRepositoryImpl.swift
+++ b/Wable-iOS/Data/RepositoryImpl/UserSessionRepositoryImpl.swift
@@ -116,24 +116,17 @@ extension UserSessionRepositoryImpl: UserSessionRepository {
 
 extension UserSessionRepositoryImpl {
     func checkAutoLogin() -> AnyPublisher<Bool, Error> {
-            guard let userSession = fetchActiveUserSession(),
-                  userSession.isAutoLoginEnabled == true else {
-                return .just(false)
-            }
-            
-            do {
-                let _ = try tokenStorage.load(.wableAccessToken), _ = try tokenStorage.load(.wableRefreshToken)
-                return .just(true)
-            } catch {
-                return .fail(error)
-            }
+        guard let userSession = fetchActiveUserSession(),
+              userSession.isAutoLoginEnabled == true
+        else {
+            return .just(false)
         }
         
-        func enableAutoLogin(for userID: Int) {
-            updateAutoLogin(enabled: true, forUserID: userID)
+        do {
+            let _ = try tokenStorage.load(.wableAccessToken), _ = try tokenStorage.load(.wableRefreshToken)
+            return .just(true)
+        } catch {
+            return .fail(error)
         }
-        
-        func disableAutoLogin(for userID: Int) {
-            updateAutoLogin(enabled: false, forUserID: userID)
-        }
+    }
 }

--- a/Wable-iOS/Data/RepositoryImpl/UserSessionRepositoryImpl.swift
+++ b/Wable-iOS/Data/RepositoryImpl/UserSessionRepositoryImpl.swift
@@ -18,6 +18,8 @@ class UserSessionRepositoryImpl {
     private let userDefaults: LocalKeyValueProvider
     private let tokenStorage = TokenStorage(keyChainStorage: KeychainStorage())
     
+    // MARK: - LifeCycle
+
     init(userDefaults: LocalKeyValueProvider) {
         self.userDefaults = userDefaults
     }
@@ -54,25 +56,6 @@ extension UserSessionRepositoryImpl: UserSessionRepository {
         
         if fetchActiveUserID() == nil {
             updateActiveUserID(userID)
-        }
-    }
-    
-    func updateAutoLogin(enabled: Bool, forUserID userID: Int) {
-        var sessions = fetchAllUserSessions()
-        
-        if let session = sessions[userID] {
-            let updatedSession = UserSession(
-                id: session.id,
-                nickname: session.nickname,
-                profileURL: session.profileURL,
-                isPushAlarmAllowed: session.isPushAlarmAllowed,
-                isAdmin: session.isAdmin,
-                isAutoLoginEnabled: enabled,
-                notificationBadgeCount: session.notificationBadgeCount
-            )
-            
-            sessions[userID] = updatedSession
-            try? userDefaults.setValue(sessions, for: Keys.userSessions)
         }
     }
     
@@ -123,7 +106,8 @@ extension UserSessionRepositoryImpl {
         }
         
         do {
-            let _ = try tokenStorage.load(.wableAccessToken), _ = try tokenStorage.load(.wableRefreshToken)
+            let _ = try tokenStorage.load(.wableAccessToken),
+                _ = try tokenStorage.load(.wableRefreshToken)
             return .just(true)
         } catch {
             return .fail(error)

--- a/Wable-iOS/Domain/RepositoryInterface/UserSessionRepository.swift
+++ b/Wable-iOS/Domain/RepositoryInterface/UserSessionRepository.swift
@@ -17,9 +17,7 @@ protocol UserSessionRepository {
     func fetchActiveUserSession() -> UserSession?
     func fetchActiveUserID() -> Int?
     func updateUserSession(_ session: UserSession, forUserID userID: Int)
-    func updateAutoLogin(enabled: Bool, forUserID userID: Int)
     func updateNotificationBadge(count: Int, forUserID userID: Int)
     func updateActiveUserID(_ userID: Int?)
     func removeUserSession(forUserID userID: Int)
-    func checkAutoLogin() -> AnyPublisher<Bool, Error>
 }

--- a/Wable-iOS/Domain/UseCase/Login/FetchUserAuthUseCase.swift
+++ b/Wable-iOS/Domain/UseCase/Login/FetchUserAuthUseCase.swift
@@ -11,6 +11,7 @@ import Combine
 final class FetchUserAuthUseCase {
     private let loginRepository: LoginRepository
     private let userSessionRepository: UserSessionRepository
+    private let tokenStorage = TokenStorage(keyChainStorage: KeychainStorage())
     
     init(loginRepository: LoginRepository, userSessionRepository: UserSessionRepository) {
         self.loginRepository = loginRepository
@@ -23,8 +24,17 @@ final class FetchUserAuthUseCase {
 extension FetchUserAuthUseCase {
     func execute(platform: SocialPlatform) -> AnyPublisher<Account, WableError> {
         return loginRepository.fetchUserAuth(platform: platform, userName: nil)
-            .handleEvents(receiveOutput: { [weak self] account in
-                guard let self = self else { return }
+            .handleEvents(receiveOutput: { account in
+                do {
+                    try self.tokenStorage.save(account.token.accessToken, for: .wableAccessToken)
+                    
+                    WableLogger.log("액세스 토큰 저장 성공: \(account.token.accessToken)", for: .debug)
+                    try self.tokenStorage.save(account.token.refreshToken, for: .wableRefreshToken)
+                    
+                    WableLogger.log("리프레시 토큰 저장 성공: \(account.token.refreshToken)", for: .debug)
+                } catch {
+                    WableLogger.log("토큰 저장 실패: \(error)", for: .debug)
+                }
                 
                 self.userSessionRepository.updateAutoLogin(
                     enabled: true,

--- a/Wable-iOS/Domain/UseCase/Login/FetchUserAuthUseCase.swift
+++ b/Wable-iOS/Domain/UseCase/Login/FetchUserAuthUseCase.swift
@@ -36,11 +36,6 @@ extension FetchUserAuthUseCase {
                     WableLogger.log("토큰 저장 실패: \(error)", for: .debug)
                 }
                 
-                self.userSessionRepository.updateAutoLogin(
-                    enabled: true,
-                    forUserID: account.user.id
-                )
-                
                 self.userSessionRepository.updateUserSession(
                     UserSession(
                         id: account.user.id,

--- a/Wable-iOS/Infra/Auth/AppleAuthProvider.swift
+++ b/Wable-iOS/Infra/Auth/AppleAuthProvider.swift
@@ -46,7 +46,7 @@ extension AppleAuthProvider: ASAuthorizationControllerDelegate {
             do {
                 try tokenStorage.save(tokenText, for: .loginAccessToken)
                 WableLogger.log("애플 로그인 토큰 저장 완료", for: .debug)
-                promise(.success(appleIDCredential.user))
+                promise(.success(appleIDCredential.fullName?.formatted()))
             } catch {
                 WableLogger.log("애플 로그인 토큰 저장 중 오류 발생: \(error)", for: .error)
                 promise(.failure(.networkError))

--- a/Wable-iOS/Infra/Auth/AppleAuthProvider.swift
+++ b/Wable-iOS/Infra/Auth/AppleAuthProvider.swift
@@ -32,25 +32,32 @@ final class AppleAuthProvider: NSObject, AuthProvider {
 // MARK: - ASAuthorizationControllerDelegate
 
 extension AppleAuthProvider: ASAuthorizationControllerDelegate {
-    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
         guard let promise = self.promise else { return }
         
-        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
-            try? tokenStorage.save("", for: .kakaoAccessToken)
-            promise(.success(appleIDCredential.user))
-        } else {
-            promise(.failure(.failedToValidateAppleLogin))
+        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
+           let token = appleIDCredential.identityToken,
+           let tokenText = String(data: token, encoding: .utf8) {
+            WableLogger.log("애플 로그인 토큰 추출 완료", for: .debug)
+            
+            do {
+                try tokenStorage.save(tokenText, for: .loginAccessToken)
+                WableLogger.log("애플 로그인 토큰 저장 완료", for: .debug)
+                promise(.success(appleIDCredential.user))
+            } catch {
+                WableLogger.log("애플 로그인 토큰 저장 중 오류 발생: \(error)", for: .error)
+                promise(.failure(.networkError))
+            }
         }
-        
-        self.promise = nil
     }
     
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         guard let promise = self.promise else { return }
         
         promise(.failure(.failedToValidateAppleLogin))
-        
-        self.promise = nil
     }
 }
 

--- a/Wable-iOS/Infra/Auth/KakaoAuthProvider.swift
+++ b/Wable-iOS/Infra/Auth/KakaoAuthProvider.swift
@@ -51,9 +51,11 @@ private extension KakaoAuthProvider {
         }
         
         do {
-            try tokenStorage.save(token, for: .kakaoAccessToken)
+            try tokenStorage.save(token, for: .loginAccessToken)
+            WableLogger.log("카카오 로그인 토큰 저장 완료", for: .debug)
             promise(.success(token))
         } catch {
+            WableLogger.log("카카오 로그인 토큰 저장 중 오류 발생: \(error)", for: .debug)
             promise(.failure(.networkError))
         }
     }

--- a/Wable-iOS/Infra/Local/KeychainStorage.swift
+++ b/Wable-iOS/Infra/Local/KeychainStorage.swift
@@ -9,7 +9,9 @@
 import Foundation
 import Security
 
-struct KeychainStorage { }
+struct KeychainStorage {
+    private let jsonDecoder = JSONDecoder()
+}
 
 extension KeychainStorage: LocalKeyValueProvider {
     func setValue<T>(_ value: T, for key: String) throws where T : Decodable, T : Encodable {
@@ -23,7 +25,7 @@ extension KeychainStorage: LocalKeyValueProvider {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: key,
-            kSecAttrService as String: Bundle.main.bundleIdentifier ?? "com.wable.Wable-iOS",
+            kSecAttrService as String: Bundle.identifier,
             kSecValueData as String: stringData
         ]
         
@@ -40,8 +42,8 @@ extension KeychainStorage: LocalKeyValueProvider {
         var item: AnyObject?
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: key,  // key 값을 kSecAttrAccount에 사용해야 함
-            kSecAttrService as String: Bundle.main.bundleIdentifier ?? "com.wable.Wable-iOS",
+            kSecAttrAccount as String: key,
+            kSecAttrService as String: Bundle.identifier,
             kSecReturnData as String: kCFBooleanTrue!,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
@@ -66,7 +68,7 @@ extension KeychainStorage: LocalKeyValueProvider {
             return stringValue as? T
         }
         
-        return try JSONDecoder().decode(T.self, from: data)
+        return try jsonDecoder.decode(T.self, from: data)
     }
     
     func removeValue(for key: String) throws {

--- a/Wable-iOS/Infra/Local/KeychainStorage.swift
+++ b/Wable-iOS/Infra/Local/KeychainStorage.swift
@@ -13,11 +13,20 @@ struct KeychainStorage { }
 
 extension KeychainStorage: LocalKeyValueProvider {
     func setValue<T>(_ value: T, for key: String) throws where T : Decodable, T : Encodable {
-        let data = try JSONEncoder().encode(String(data: value as! Data, encoding: .utf8))
+        let data: Data
+        if let stringValue = value as? String {
+            guard let stringData = stringValue.data(using: .utf8) else {
+                throw LocalError.saveFailed
+            }
+            data = stringData
+        } else {
+            data = try JSONEncoder().encode(value)
+        }
         
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: key,
+            kSecAttrAccount as String: key,
+            kSecAttrService as String: Bundle.main.bundleIdentifier ?? "com.wable.Wable-iOS",
             kSecValueData as String: data
         ]
         

--- a/Wable-iOS/Infra/Network/APIProvider.swift
+++ b/Wable-iOS/Infra/Network/APIProvider.swift
@@ -6,7 +6,7 @@
 //
 
 import Combine
-import Foundation
+import UIKit
 
 import Alamofire
 import CombineMoya
@@ -17,10 +17,8 @@ final class APIProvider<Target: BaseTargetType>: MoyaProvider<Target> {
     private let interceptor: AuthenticationInterceptor<OAuthenticator>
     
     init() {
-        WableLogger.log("APIProvider 초기화 시작", for: .debug)
         
         let authenticator = OAuthenticator(
-            errorMonitor: OAuthErrorMonitor(),
             tokenStorage: TokenStorage(keyChainStorage: KeychainStorage())
         )
         
@@ -35,10 +33,20 @@ final class APIProvider<Target: BaseTargetType>: MoyaProvider<Target> {
             credential: credential
         )
         
-        let session = Session(interceptor: interceptor)
-        let plugin: [PluginType] = [MoyaLoggingPlugin()]
+        let logoutHandler = {
+            let userSessionRepository = UserSessionRepositoryImpl(userDefaults: UserDefaultsStorage(
+                userDefaults: UserDefaults.standard,
+                jsonEncoder: JSONEncoder(),
+                jsonDecoder: JSONDecoder()
+            ))
+            
+            userSessionRepository.updateActiveUserID(nil)
+            
+            OAuthEventManager.shared.tokenExpiredSubject.send()
+        }
         
-        WableLogger.log("APIProvider session 및 interceptor 설정 완료", for: .debug)
+        let session = Session(interceptor: interceptor)
+        let plugin: [PluginType] = [MoyaLoggingPlugin(logoutHandler: logoutHandler)]
         
         super.init(session: session, plugins: plugin)
     }
@@ -48,9 +56,11 @@ final class APIProvider<Target: BaseTargetType>: MoyaProvider<Target> {
         for type: D.Type
     ) -> AnyPublisher<D, NetworkError> {
         return self.requestPublisher(target)
-            .map(\.data)
+            .map { $0.data }
             .decode(type: BaseResponse<D>.self, decoder: jsonDecoder)
-            .tryMap(validateResponse)
+            .tryMap { response in
+                return try self.validateResponse(response)
+            }
             .mapError { error in
                 if let decodingError = error as? DecodingError {
                     return .decodedError(decodingError)

--- a/Wable-iOS/Infra/Network/APIProvider.swift
+++ b/Wable-iOS/Infra/Network/APIProvider.swift
@@ -17,15 +17,28 @@ final class APIProvider<Target: BaseTargetType>: MoyaProvider<Target> {
     private let interceptor: AuthenticationInterceptor<OAuthenticator>
     
     init() {
-        self.interceptor = AuthenticationInterceptor(
-            authenticator: OAuthenticator(
-                errorMonitor: OAuthErrorMonitor(),
-                tokenStorage: TokenStorage(keyChainStorage: KeychainStorage())
-            )
+        WableLogger.log("APIProvider 초기화 시작", for: .debug)
+        
+        let authenticator = OAuthenticator(
+            errorMonitor: OAuthErrorMonitor(),
+            tokenStorage: TokenStorage(keyChainStorage: KeychainStorage())
         )
         
-        let session: Session = .init(interceptor: interceptor)
+        let credential = OAuthCredential(
+            accessToken: "",
+            refreshToken: "",
+            requiresRefresh: false
+        )
+        
+        self.interceptor = AuthenticationInterceptor(
+            authenticator: authenticator,
+            credential: credential
+        )
+        
+        let session = Session(interceptor: interceptor)
         let plugin: [PluginType] = [MoyaLoggingPlugin()]
+        
+        WableLogger.log("APIProvider session 및 interceptor 설정 완료", for: .debug)
         
         super.init(session: session, plugins: plugin)
     }

--- a/Wable-iOS/Infra/Network/MoyaLoggingPlugin.swift
+++ b/Wable-iOS/Infra/Network/MoyaLoggingPlugin.swift
@@ -128,11 +128,8 @@ private extension MoyaLoggingPlugin {
                 do {
                     try owner.tokenStorage.save(token.accessToken, for: .wableAccessToken)
                     try owner.tokenStorage.save(token.refreshToken, for: .wableRefreshToken)
-                    
-                    let toast = ToastView(status: .caution, message: "다시 시도하세요")
-                    toast.show()
                 } catch {
-                    WableLogger.log("당신은 이제 망햇습니다...", for: .error)
+                    WableLogger.log("토큰 재발급 중 문제 발생", for: .error)
                     owner.logoutHandler?()
                 }
             }

--- a/Wable-iOS/Infra/Network/MoyaLoggingPlugin.swift
+++ b/Wable-iOS/Infra/Network/MoyaLoggingPlugin.swift
@@ -11,6 +11,23 @@ import Moya
 
 final class MoyaLoggingPlugin: PluginType {
     
+    // MARK: Property
+    
+    typealias LogoutHandler = () -> Void
+    private let cancelBag = CancelBag()
+    private let logoutHandler: LogoutHandler?
+    private let tokenStorage: TokenStorage
+    
+    // MARK: - LifeCycle
+
+    init(
+        logoutHandler: LogoutHandler? = nil,
+        tokenStorage: TokenStorage = TokenStorage(keyChainStorage: KeychainStorage())
+    ) {
+        self.logoutHandler = logoutHandler
+        self.tokenStorage = tokenStorage
+    }
+    
     // MARK: - Request 보낼 시 호출
     
     func willSend(_ request: RequestType, target: TargetType) {
@@ -32,7 +49,7 @@ final class MoyaLoggingPlugin: PluginType {
             bytes: body,
             encoding: String.Encoding.utf8
         ) {
-            log.append("\(bodyString)\n")
+            log.append("body: \(bodyString)\n")
         }
         
         log.append("------------------- END \(method) -------------------")
@@ -45,8 +62,12 @@ final class MoyaLoggingPlugin: PluginType {
         switch result {
         case let .success(response):
             self.onSucceed(response, target: target)
+            self.checkForAuthError(response)
         case let .failure(error):
             self.onFail(error, target: target)
+            if let response = error.response {
+                self.checkForAuthError(response)
+            }
         }
     }
     
@@ -77,5 +98,44 @@ final class MoyaLoggingPlugin: PluginType {
         log.append("\(error.failureReason ?? error.errorDescription ?? "unknown error")\n")
         log.append("<-- END HTTP")
         print(log)
+    }
+}
+
+// MARK: - Private Extension
+
+private extension MoyaLoggingPlugin {
+    private func checkForAuthError(_ response: Response) {
+        guard let condtion = response.response?.url?.absoluteString.contains("v1/auth/token"),
+              response.statusCode == 401 && !condtion else { return }
+        
+        let tokenProvider = OAuthTokenProvider()
+        
+        tokenProvider.updateTokenStatus()
+            .withUnretained(self)
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    if error == .signinRequired {
+                        try? self?.tokenStorage.delete(.wableAccessToken)
+                        try? self?.tokenStorage.delete(.wableRefreshToken)
+                        
+                        self?.logoutHandler?()
+                    }
+                }
+            } receiveValue: { owner, token in
+                do {
+                    try owner.tokenStorage.save(token.accessToken, for: .wableAccessToken)
+                    try owner.tokenStorage.save(token.refreshToken, for: .wableRefreshToken)
+                    
+                    let toast = ToastView(status: .caution, message: "다시 시도하세요")
+                    toast.show()
+                } catch {
+                    WableLogger.log("당신은 이제 망햇습니다...", for: .error)
+                    owner.logoutHandler?()
+                }
+            }
+            .store(in: cancelBag)
     }
 }

--- a/Wable-iOS/Infra/Network/OAuth/OAuthEventManager.swift
+++ b/Wable-iOS/Infra/Network/OAuth/OAuthEventManager.swift
@@ -8,8 +8,8 @@
 
 import Combine
 
-final class AuthEventManager {
-    static let shared = AuthEventManager()
+final class OAuthEventManager {
+    static let shared = OAuthEventManager()
     
     let tokenExpiredSubject = PassthroughSubject<Void, Never>()
 }

--- a/Wable-iOS/Infra/Network/OAuth/OAuthEventManager.swift
+++ b/Wable-iOS/Infra/Network/OAuth/OAuthEventManager.swift
@@ -1,0 +1,15 @@
+//
+//  OAuthEventManager.swift
+//  Wable-iOS
+//
+//  Created by YOUJIM on 3/23/25.
+//
+
+
+import Combine
+
+final class AuthEventManager {
+    static let shared = AuthEventManager()
+    
+    let tokenExpiredSubject = PassthroughSubject<Void, Never>()
+}

--- a/Wable-iOS/Infra/Network/OAuth/OAuthenticator.swift
+++ b/Wable-iOS/Infra/Network/OAuth/OAuthenticator.swift
@@ -13,22 +13,21 @@ import Alamofire
 final class OAuthenticator: Authenticator {
     typealias Credential = OAuthCredential
     
-    private let errorMonitor: OAuthErrorMonitor
     private let tokenStorage: TokenStorage
     
-    init(errorMonitor: OAuthErrorMonitor, tokenStorage: TokenStorage) {
-        self.errorMonitor = errorMonitor
+    init(tokenStorage: TokenStorage) {
         self.tokenStorage = tokenStorage
     }
     
     /// 토큰 재발급 API를 제외하고 다른 API 통신을 진행할 때 헤더를 설정하는 메서드
-    /// 소셜 로그인 통신 시 카카오 엑세스 토큰 무조건 삽입되도록 설정
+    /// 소셜 로그인 통신 시 로그인 엑세스 토큰 무조건 삽입되도록 설정
     func apply(_ credential: OAuthCredential, to urlRequest: inout URLRequest) {
+        guard let urlString = urlRequest.url?.absoluteString else { return }
         var headers = urlRequest.headers
         
         do {
             let tokenType: TokenStorage.TokenType = {
-                if let urlString = urlRequest.url?.absoluteString, urlString.contains("v2/auth") {
+                if urlString.contains("v2/auth") {
                     WableLogger.log("소셜 로그인을 위해 loginAccessToken으로 헤더 설정", for: .debug)
                     return .loginAccessToken
                 } else {
@@ -37,25 +36,35 @@ final class OAuthenticator: Authenticator {
                 }
             }()
             
-            let token = try tokenStorage.load(tokenType)
-            WableLogger.log("토큰 불러오기 성공: \(String(token.prefix(10)))...", for: .debug)
+            if urlString.contains("v1/auth/token") {
+                let accessToken = try tokenStorage.load(.wableAccessToken)
+                let refreshToken = try tokenStorage.load(.wableRefreshToken)
+                
+                WableLogger.log("토큰 재발급을 위한 현재 토큰 불러오기 성공: \(String(accessToken.prefix(10)))...", for: .debug)
+                
+                headers.add(.authorization(bearerToken: accessToken))
+                headers.add(name: "Refresh", value: "Bearer \(refreshToken)")
+            } else {
+                let token = try tokenStorage.load(tokenType)
+                WableLogger.log("토큰 불러오기 성공: \(String(token.prefix(10)))...", for: .debug)
+                
+                headers.add(.authorization(bearerToken: token))
+            }
             
-            headers.add(.authorization(bearerToken: token))
             urlRequest.headers = headers
             
-            WableLogger.log("요청 헤더에 토큰 추가 완료", for: .debug)
+            WableLogger.log("요청 헤더에 토큰 추가 완료: \(urlRequest.headers)", for: .debug)
         } catch {
             WableLogger.log("토큰 불러오기 실패: \(error.localizedDescription)", for: .error)
         }
     }
     
-    /// API 요청 중 에러가 발생했을 때 응답 코드가 401인 경우만 refresh가 실행되도록 처리하는 메서드
     func didRequest(
         _ urlRequest: URLRequest,
         with response: HTTPURLResponse,
         failDueToAuthenticationError error: any Error
     ) -> Bool {
-        return errorMonitor.isUnauthorized
+        return false
     }
     
     /// 인증이 필요한 urlRequest에 대해서만 true를 리턴해 refresh가 실행되도록 처리하는 메서드
@@ -64,47 +73,11 @@ final class OAuthenticator: Authenticator {
         
         return urlRequest.headers["Authorization"] == token
     }
-
-    /// 토큰 갱신을 위해 updateTokenStatus를 실행하고 받아온 결과를 TokenStorage에 저장하는 메서드
+    
+    
     func refresh(
         _ credential: OAuthCredential,
         for session: Alamofire.Session,
         completion: @escaping (Result<OAuthCredential, any Error>) -> Void
-    ) {
-        let repository = OAuthTokenProvider()
-        
-        repository.updateTokenStatus()
-            .sink(
-                receiveCompletion: { status in
-                    if case .failure(let error) = status {
-                        let userSessionRepository = UserSessionRepositoryImpl(
-                            userDefaults: UserDefaultsStorage(
-                            jsonEncoder: JSONEncoder(),
-                            jsonDecoder: JSONDecoder()
-                            ))
-                        
-                        if error == .signinRequired {
-                            guard let id = userSessionRepository.fetchActiveUserID() else { return }
-                            
-                            userSessionRepository.removeUserSession(forUserID: id)
-                            
-                            AuthEventManager.shared.tokenExpiredSubject.send()
-                        }
-                        
-                        completion(.failure(error))
-                    }
-                }, receiveValue: { token in
-                    do {
-                        try self.tokenStorage.save(token.accessToken, for: .wableAccessToken)
-                        try self.tokenStorage.save(token.refreshToken, for: .wableRefreshToken)
-                    } catch {
-                        completion(.failure(error))
-                        return
-                    }
-                    
-                    completion(.success(credential))
-                }
-            )
-            .cancel()
-    }
+    ) { }
 }

--- a/Wable-iOS/Infra/Network/TargetType/BaseTargetType.swift
+++ b/Wable-iOS/Infra/Network/TargetType/BaseTargetType.swift
@@ -39,7 +39,7 @@ extension BaseTargetType {
     }
     
     var validationType: ValidationType {
-        return .successCodes
+        return .none 
     }
     
     var headers: [String : String]? {

--- a/Wable-iOS/Infra/Network/TargetType/ContentTargetType.swift
+++ b/Wable-iOS/Infra/Network/TargetType/ContentTargetType.swift
@@ -28,7 +28,7 @@ extension ContentTargetType: BaseTargetType {
         case .fetchContentInfo(contentID: let contentID):
             return "/v3/content/\(contentID)"
         case .fetchContentList:
-            return "/api/v3/contents"
+            return "/v3/contents"
         case .fetchUserContentList(memberID: let memberID):
             return "/v3/member/\(memberID)/contents"
         }

--- a/Wable-iOS/Infra/Token/TokenStorage.swift
+++ b/Wable-iOS/Infra/Token/TokenStorage.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct TokenStorage {
     enum TokenType: String {
-        case kakaoAccessToken = "kakaoAccessToken"
+        case loginAccessToken = "loginAccessToken"
         case wableAccessToken = "accessToken"
         case wableRefreshToken = "refreshToken"
     }
@@ -28,11 +28,12 @@ extension TokenStorage {
     }
     
     func load(_ tokenType: TokenType) throws -> String {
-        guard let token: String = try keychainStorage.getValue(for: tokenType.rawValue) else {
+        guard let token: Data = try keychainStorage.getValue(for: tokenType.rawValue),
+              let tokenString = String(data: token, encoding: .utf8) else {
             throw TokenError.dataConversionFailed
         }
         
-        return token
+        return tokenString
     }
     
     func delete(_ tokenType: TokenType) throws {

--- a/Wable-iOS/Presentation/Home/HomeViewController.swift
+++ b/Wable-iOS/Presentation/Home/HomeViewController.swift
@@ -10,4 +10,34 @@ import UIKit
 
 final class HomeViewController: UIViewController {
     
+    // MARK: Property
+
+    let contentRepostiory: ContentRepository
+    let cancelBag = CancelBag()
+    
+    // MARK: - LifeCycle
+
+    init(contentRepostiory: ContentRepository) {
+        self.contentRepostiory = contentRepostiory
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        contentRepostiory.fetchContentList(cursor: -1)
+            .receive(on: DispatchQueue.main)
+            .withUnretained(self)
+            .sink { completion in
+                WableLogger.log("fetchContentList 실행 완", for: .debug)
+            } receiveValue: { owner, list in
+                print(list)
+            }
+            .store(in: cancelBag)
+    }
 }

--- a/Wable-iOS/Presentation/Login/LoginViewController.swift
+++ b/Wable-iOS/Presentation/Login/LoginViewController.swift
@@ -170,11 +170,12 @@ private extension LoginViewController {
             cancelBag: cancelBag
         )
         
-        output.loginSuccess
+        output.account
             .receive(on: DispatchQueue.main)
             .withUnretained(self)
             .sink { owner, sessionInfo in
-                owner.navigateToHome()
+                WableLogger.log("새로운 유저인가요? : \(sessionInfo.isNewUser)", for: .debug)
+                sessionInfo.isNewUser ? owner.navigateToOnboarding() : owner.navigateToHome()
             }
             .store(in: cancelBag)
     }

--- a/Wable-iOS/Presentation/Login/LoginViewModel.swift
+++ b/Wable-iOS/Presentation/Login/LoginViewModel.swift
@@ -1,0 +1,79 @@
+//
+//  LoginViewModel.swift
+//  Wable-iOS
+//
+//  Created by YOUJIM on 3/23/25.
+//
+
+
+import Combine
+import Foundation
+
+final class LoginViewModel {
+    
+    // MARK: Property
+
+    private let fetchUserAuthUseCase: FetchUserAuthUseCase
+    private let loginSuccessSubject = PassthroughSubject<Account, Never>()
+    private let loginErrorSubject = PassthroughSubject<WableError, Never>()
+    
+    // MARK: - LifeCycle
+
+    init(useCase: FetchUserAuthUseCase) {
+        self.fetchUserAuthUseCase = useCase
+    }
+}
+
+// MARK: - Extension
+
+extension LoginViewModel: ViewModelType {
+    struct Input {
+        let kakaoLoginTrigger: AnyPublisher<Void, Never>
+        let appleLoginTrigger: AnyPublisher<Void, Never>
+    }
+    
+    struct Output {
+        let loginSuccess: AnyPublisher<Account, Never>
+        /// 이후 로그인 실패 시 에러 추가될 것을 고려해 추가해둠
+        let loginError: AnyPublisher<WableError, Never>
+    }
+    
+    func transform(input: Input, cancelBag: CancelBag) -> Output {
+        input.kakaoLoginTrigger
+            .flatMap { _ -> AnyPublisher<Account, WableError> in
+                return self.fetchUserAuthUseCase.execute(platform: .kakao)
+            }
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        self.loginErrorSubject.send(error)
+                    }
+                },
+                receiveValue: { account in
+                    self.loginSuccessSubject.send(account)
+                }
+            )
+            .store(in: cancelBag)
+        
+        input.appleLoginTrigger
+            .flatMap { _ -> AnyPublisher<Account, WableError> in
+                return self.fetchUserAuthUseCase.execute(platform: .apple)
+            }
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        self.loginErrorSubject.send(error)
+                    }
+                },
+                receiveValue: { account in
+                    self.loginSuccessSubject.send(account)
+                }
+            )
+            .store(in: cancelBag)
+        
+        return Output(
+            loginSuccess: loginSuccessSubject.eraseToAnyPublisher(),
+            loginError: loginErrorSubject.eraseToAnyPublisher()
+        )
+    }
+}

--- a/Wable-iOS/Presentation/TabBar/TabBarController.swift
+++ b/Wable-iOS/Presentation/TabBar/TabBarController.swift
@@ -12,7 +12,7 @@ final class TabBarController: UITabBarController {
     
     // MARK: - UIComponent
     
-    private let homeViewController = HomeViewController().then {
+    private let homeViewController = HomeViewController(contentRepostiory: ContentRepositoryImpl()).then {
         $0.tabBarItem.title = "홈"
         $0.tabBarItem.image = .icHomeDefault
     }

--- a/Wable-iOS/Presentation/TabBar/TabBarController.swift
+++ b/Wable-iOS/Presentation/TabBar/TabBarController.swift
@@ -43,6 +43,7 @@ final class TabBarController: UITabBarController {
         super.init(nibName: nil, bundle: nil)
         
         modalPresentationStyle = .fullScreen
+        modalTransitionStyle = .crossDissolve
     }
     
     required init?(coder: NSCoder) {

--- a/Wable-iOS/Resource/Info.plist
+++ b/Wable-iOS/Resource/Info.plist
@@ -6,6 +6,17 @@
 	<string>$(AMPLITUDE_APP_KEY)</string>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao${NATIVE_APP_KEY}</string>
+			</array>
+		</dict>
+	</array>
 	<key>FirebaseAppDelegateProxyEnabled</key>
 	<string>NO</string>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 카카오 로그인, 애플 로그인을 구현했어요.
- 자동 로그인 및 토큰 갱신 로직을 구현했어요.
  - Interceptor에서 처리가 블가능하던 401 재로그인 메시지 분기 처리를 MoyaPlugin으로 옮겨 구현했어요.
- KeyChainStorage에서 값을 제대로 불러올 수 없었던 오류를 수정했어요.

|    구현 내용    |   카카오 로그인 (기존 유저)   |   애플 로그인 (신규 유저)  |
| :-------------: | :----------: |  :----------: |
| IPhone 13 mini | <img src = "https://github.com/user-attachments/assets/5102a186-5aa2-4250-b389-f4ca75d26df2"> | <img src = "https://github.com/user-attachments/assets/19b119c5-3daa-4142-80a6-5c3a5778b030"> |

## 💻 주요 로직 시퀀스 다이어그램
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 앱 시작 및 자동 로그인 프로세스
```mermaid
sequenceDiagram
    participant SD as SceneDelegate
    participant OEM as OAuthEventManager
    participant USR as UserSessionRepository
    participant TS as TokenStorage
    participant TBC as TabBarController
    participant LVC as LoginViewController
    
    %% 초기화 및 이벤트 핸들러 등록
    SD->>OEM: tokenExpiredSubject 구독
    OEM-->>SD: 이벤트 구독 성공
    
    %% 앱 시작 및 자동 로그인 프로세스
    SD->>USR: checkAutoLogin()
    USR->>TS: 토큰 존재 확인
    
    alt 자동 로그인 활성화 + 토큰 존재
        TS-->>USR: 토큰 확인 완료
        USR-->>SD: true 반환
        SD->>TBC: present TabBarController
    else 자동 로그인 비활성화 또는 토큰 없음
        TS-->>USR: 토큰 없음 또는 자동 로그인 비활성화
        USR-->>SD: false 반환
        SD->>LVC: present LoginViewController(viewModel)
    end
```

### 로그인 후 API 호출 성공 시나리오
```mermaid
sequenceDiagram
    participant HVC as HomeViewController
    participant CR as ContentRepository
    participant API as APIProvider
    participant MLP as MoyaLoggingPlugin
    participant OA as OAuthenticator
    participant TS as TokenStorage
    
    %% API 호출 프로세스 (성공 시나리오)
    HVC->>CR: fetchContentList(cursor: -1)
    CR->>API: request()
    API->>MLP: willSend()
    MLP-->>API: 요청 로깅
    API->>OA: apply(credential, to: request)
    OA->>TS: load(.wableAccessToken)
    TS-->>OA: accessToken 반환
    OA-->>API: Authorization 헤더 설정
    
    %% API 응답 처리 (성공)
    API-->>MLP: didReceive(result)
    MLP-->>API: 응답 로깅
    API-->>CR: 성공 응답 반환
    CR-->>HVC: 데이터 반환
```

### 토큰 갱신 성공 시나리오
```mermaid
sequenceDiagram
    participant HVC as HomeViewController
    participant CR as ContentRepository
    participant API as APIProvider
    participant MLP as MoyaLoggingPlugin
    participant OTP as OAuthTokenProvider
    participant TS as TokenStorage
    
    %% API 응답 실패 (401) 후 토큰 갱신 성공
    HVC->>CR: fetchContentList(cursor: -1)
    CR->>API: request()
    API-->>MLP: didReceive(result) - 401 에러
    
    MLP->>MLP: checkForAuthError(response)
    Note over MLP: 401 에러 + URL 조건 검사
    
    MLP->>OTP: updateTokenStatus()
    OTP-->>MLP: 새 토큰 반환
    
    MLP->>TS: save(token.accessToken)
    MLP->>TS: save(token.refreshToken)
    
    Note over MLP,API: 다음 요청부터 새 토큰 사용
    
    %% 재요청 (다음 요청 자동 재시도는 아님)
    HVC->>CR: fetchContentList(cursor: -1) 재요청
    CR->>API: request() (새 토큰 사용)
    API-->>CR: 성공 응답 반환
    CR-->>HVC: 데이터 반환
```

### 토큰 갱신 실패 시나리오
```mermaid
sequenceDiagram
    participant HVC as HomeViewController
    participant CR as ContentRepository
    participant API as APIProvider
    participant MLP as MoyaLoggingPlugin
    participant OTP as OAuthTokenProvider
    participant TS as TokenStorage
    participant OEM as OAuthEventManager
    participant SD as SceneDelegate
    participant USR as UserSessionRepository
    
    %% API 응답 실패 (401) 후 토큰 갱신 실패
    HVC->>CR: fetchContentList(cursor: -1)
    CR->>API: request()
    API-->>MLP: didReceive(result) - 401 에러
    
    MLP->>MLP: checkForAuthError(response)
    Note over MLP: 401 에러 + URL 조건 검사
    
    MLP->>OTP: updateTokenStatus()
    OTP-->>MLP: WableError.signinRequired 에러
    
    MLP->>TS: delete(.wableAccessToken)
    MLP->>TS: delete(.wableRefreshToken)
    MLP->>MLP: logoutHandler() 호출
    
    MLP->>OEM: tokenExpiredSubject.send()
    OEM-->>SD: 토큰 만료 이벤트 발생
    
    SD->>SD: handleTokenExpired()
    SD->>USR: updateActiveUserID(nil)
    SD->>SD: configureLoginScreen()
    SD->>SD: ToastView("세션이 만료되었습니다").show()
```

### 💻 주요 코드 설명

### 1. 소셜 로그인 구현

#### 애플 로그인
```swift
// AppleAuthProvider.swift
func authenticate() -> AnyPublisher<String?, WableError> {
    return Future<String?, WableError> { promise in
        self.promise = promise
        
        let request = ASAuthorizationAppleIDProvider().createRequest()
        request.requestedScopes = [.fullName]
        
        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
        authorizationController.delegate = self
        authorizationController.presentationContextProvider = self
        authorizationController.performRequests()
    }
    .eraseToAnyPublisher()
}
```
- `ASAuthorizationController`를 사용해 애플 로그인 요청을 처리하고 `Future` 타입으로 감싸 `Combine` 기반 비동기 작업을 수행했습니다.
- 인증 결과는 `delegate` 메서드를 통해 `promise`에 전달됩니다.

#### 카카오 로그인
```swift
// KakaoAuthProvider.swift
func authenticate() -> AnyPublisher<String?, WableError> {
    return Future<String?, WableError> { promise in
        if KakaoUserAPI.isKakaoTalkLoginAvailable() {
            KakaoUserAPI.shared.loginWithKakaoTalk { [weak self] (oauthToken, error) in
                self?.handleKakaoAuthResult(oauthToken: oauthToken, error: error, promise: promise)
            }
        } else {
            KakaoUserAPI.shared.loginWithKakaoAccount { [weak self] (oauthToken, error) in
                self?.handleKakaoAuthResult(oauthToken: oauthToken, error: error, promise: promise)
            }
        }
    }
    .eraseToAnyPublisher()
}
```
- 카카오톡 앱이 설치되어 있으면 앱을, 없으면 웹뷰를 통해 로그인할 수 있도록 분기 처리를 진행했습니다. 
- 애플 로그인과 마찬가지로 `Future`와 `Combine`을 통해 비동기 처리를 구현했습니다.

### 2. 자동 로그인 구현

```swift
// UserSessionRepositoryImpl.swift
func checkAutoLogin() -> AnyPublisher<Bool, Error> {
    guard let userSession = fetchActiveUserSession(),
          userSession.isAutoLoginEnabled == true else {
        return .just(false)
    }
    
    do {
        let _ = try tokenStorage.load(.wableAccessToken)
        let _ = try tokenStorage.load(.wableRefreshToken)
        return .just(true)
    } catch {
        return .fail(error)
    }
}
```
- `UserSessionRepository`에서 저장된 사용자 세션을 확인하고 자동 로그인이 활성화되어 있는지와 토큰이 존재하는지 검증을 수행합니다.
- 두 조건이 모두 충족되면 true를 반환하여 자동 로그인을 진행합니다.

```swift
// SceneDelegate.swift
DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 2.0) {
    self.userSessionRepository.checkAutoLogin()
        .withUnretained(self)
        .sink { [weak self] completion in
            switch completion {
            case .finished:
                break
            case .failure(let error):
                WableLogger.log("자동 로그인 여부 체크 실패: \(error)", for: .error)
                self?.configureLoginScreen()
            }
        } receiveValue: { owner, isAutologinEnabled in
            WableLogger.log("자동 로그인 여부 체크 성공: \(isAutologinEnabled)", for: .debug)
            isAutologinEnabled ? owner.configureMainScreen() : owner.configureLoginScreen()
        }
        .store(in: self.cancelBag)
}
```
- 이후 `SceneDelegate`에서 스플래시 화면 이후 자동 로그인 체크를 진행하고 결과에 따라 메인 화면 또는 로그인 화면으로 이동합니다.

### 3. 토큰 갱신 로직 오류 해결

```swift
// MoyaLoggingPlugin.swift
private func checkForAuthError(_ response: Response) {
    guard let condtion = response.response?.url?.absoluteString.contains("v1/auth/token"),
          response.statusCode == 401 && !condtion else { return }
    
    let tokenProvider = OAuthTokenProvider()
    
    tokenProvider.updateTokenStatus()
        .withUnretained(self)
        .sink { [weak self] completion in
            switch completion {
            case .finished:
                break
            case .failure(let error):
                if error == .signinRequired {
                    try? self?.tokenStorage.delete(.wableAccessToken)
                    try? self?.tokenStorage.delete(.wableRefreshToken)
                    
                    self?.logoutHandler?()
                }
            }
        } receiveValue: { owner, token in
            do {
                try owner.tokenStorage.save(token.accessToken, for: .wableAccessToken)
                try owner.tokenStorage.save(token.refreshToken, for: .wableRefreshToken)
            } catch {
                WableLogger.log("토큰 재발급 중 문제 발생", for: .error)
                
                owner.logoutHandler?()
            }
        }
        .store(in: cancelBag)
}
```
- `Alamofire`의 `Interceptor`에서 401 에러를 처리하려 했으나 `Interceptor`에서는 통신 후의 값을 처리할 수 없기 때문에 401 재로그인 에러를 판별할 수 없는 문제가 있었습니다. 
- 이를 해결하기 위해 `MoyaLoggingPlugin`으로 로직을 이동시켜 `checkForAuthError()`에서 해당 역할을 수행하도록 코드를 개선했습니다. 
  - `checkForAuthError()`에서 401 에러를 감지하면 토큰 갱신을 시도하고, 실패할 경우 로그아웃 처리를 진행합니다.

### 4. 토큰 만료 이벤트 처리

```swift
// OAuthEventManager.swift
final class OAuthEventManager {
    static let shared = OAuthEventManager()
    
    let tokenExpiredSubject = PassthroughSubject<Void, Never>()
}
```
- 토큰 만료 이벤트를 발행하기 위한 싱글톤 클래스를 생성했습니다. 
- `Combine`의 `PassthroughSubject`를 사용하여 이벤트를 발행합니다.

```swift
// SceneDelegate.swift
func setupBinding() {
    OAuthEventManager.shared.tokenExpiredSubject
        .receive(on: DispatchQueue.main)
        .sink { [weak self] _ in
            self?.handleTokenExpired()
        }
        .store(in: cancelBag)
}

func handleTokenExpired() {
    userSessionRepository.updateActiveUserID(nil)
    configureLoginScreen()
    
    let toast = ToastView(status: .caution, message: "세션이 만료되었습니다. 다시 로그인해주세요.")
    toast.show()
}
```
- `SceneDelegate`에서 토큰 만료 이벤트를 구독하고 이벤트가 발행되면 `handleTokenExpired` 메서드를 호출해 로그아웃 처리와 함께 사용자에게 토스트 메시지를 보여줍니다.

### 5. KeyChainStorage 문제 수정

```swift
// TokenStorage.swift
func load(_ tokenType: TokenType) throws -> String {
    guard let token: String = try keychainStorage.getValue(for: tokenType.rawValue) else {
        throw TokenError.dataConversionFailed
    }
    
    return token
}
```

```swift
// KeychainStorage.swift
func getValue<T>(for key: String) throws -> T? where T : Decodable, T : Encodable {
    var item: AnyObject?
    let query: [String: Any] = [
        kSecClass as String: kSecClassGenericPassword,
        kSecAttrService as String: key,
        kSecReturnData as String: kCFBooleanTrue!,
        kSecMatchLimit as String: kSecMatchLimitOne
    ]
    
    let status = SecItemCopyMatching(query as CFDictionary, &item)
    
    guard status == errSecSuccess,
          let data = item as? Data
    else {
        throw LocalError.dataNotFound
    }
    
    return data as? T
}
```
- `KeyChainStorage`에서 값을 제대로 불러올 수 없었던 문제를 수정했습니다. 
- Data 타입을 직접 반환하도록 해 변환 과정의 오류를 해결했습니다. 

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
[Swift ) Moya Interceptor, Plugin - EEYatHo iOS](https://eeyatho.tistory.com/m/256)

## 🔗 연결된 이슈
- Resolved: #115 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced login flows with smoother Kakao and Apple sign-ins, streamlining the transition from onboarding to the home screen.
	- Proactive session management now notifies users of expiration with a toast message and directs them back to login.
- **Improvements**
	- Optimized content loading on the home screen for a fresher experience.
	- Refined modal transition animations for a more polished look.
	- Strengthened authentication token management for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->