### PR TITLE
[Fix] DIContainer 수정 및 소식 탭 앰플리튜드 태그 추가

### DIFF
--- a/Wable-iOS.xcodeproj/project.pbxproj
+++ b/Wable-iOS.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		DE54B0422D833B0B009A7C34 /* WableSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE54B0412D833B0B009A7C34 /* WableSheetViewController.swift */; };
 		DE59BB9A2D8A9D3A0040ADCB /* NotificationEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE59BB992D8A9D3A0040ADCB /* NotificationEmpty.swift */; };
 		DE59BBA92D8A9EFD0040ADCB /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE59BBA82D8A9EFD0040ADCB /* UIViewController+.swift */; };
+		DE6459CF2D97AA9D005569B8 /* AppDelegate+InjectDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6459CE2D97AA9D005569B8 /* AppDelegate+InjectDependency.swift */; };
 		DE67A9EB2D7211070021BDE1 /* Like.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67A9EA2D7211070021BDE1 /* Like.swift */; };
 		DE67A9EF2D7213D90021BDE1 /* Opacity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67A9EE2D7213D90021BDE1 /* Opacity.swift */; };
 		DE6C3E3E2D91A8E00046DB30 /* NewsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6C3E3D2D91A8E00046DB30 /* NewsViewModel.swift */; };
@@ -455,6 +456,7 @@
 		DE54B0412D833B0B009A7C34 /* WableSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WableSheetViewController.swift; sourceTree = "<group>"; };
 		DE59BB992D8A9D3A0040ADCB /* NotificationEmpty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationEmpty.swift; sourceTree = "<group>"; };
 		DE59BBA82D8A9EFD0040ADCB /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
+		DE6459CE2D97AA9D005569B8 /* AppDelegate+InjectDependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+InjectDependency.swift"; sourceTree = "<group>"; };
 		DE67A9EA2D7211070021BDE1 /* Like.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Like.swift; sourceTree = "<group>"; };
 		DE67A9EE2D7213D90021BDE1 /* Opacity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Opacity.swift; sourceTree = "<group>"; };
 		DE6C3E3D2D91A8E00046DB30 /* NewsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsViewModel.swift; sourceTree = "<group>"; };
@@ -1066,6 +1068,7 @@
 			isa = PBXGroup;
 			children = (
 				DD8CEF472D6A007900DBE580 /* AppDelegate.swift */,
+				DE6459CE2D97AA9D005569B8 /* AppDelegate+InjectDependency.swift */,
 				DD8CEF482D6A007900DBE580 /* SceneDelegate.swift */,
 			);
 			path = App;
@@ -1807,6 +1810,7 @@
 				DD29683E2D6DAD2F00143851 /* UpdateToken.swift in Sources */,
 				DE20BAD72D903985000126A4 /* AnnouncementDetailView.swift in Sources */,
 				DE70048D2D8EA85400B7AB71 /* NewsViewController.swift in Sources */,
+				DE6459CF2D97AA9D005569B8 /* AppDelegate+InjectDependency.swift in Sources */,
 				DE8E863B2D918735000A4292 /* RankViewItem.swift in Sources */,
 				DD29683F2D6DAD2F00143851 /* FetchInfoNotifications.swift in Sources */,
 				DD2968402D6DAD2F00143851 /* FetchNewsNoticeNumber.swift in Sources */,

--- a/Wable-iOS/App/AppDelegate+InjectDependency.swift
+++ b/Wable-iOS/App/AppDelegate+InjectDependency.swift
@@ -1,0 +1,18 @@
+//
+//  AppDelegate+InjectDependency.swift
+//  Wable-iOS
+//
+//  Created by 김진웅 on 3/29/25.
+//
+
+import Foundation
+
+extension AppDelegate {
+    var diContainer: AppDIContainer { AppDIContainer.shared }
+    
+    func injectDependency() {
+        
+        // TODO: 객체를 주입
+        
+    }
+}

--- a/Wable-iOS/App/AppDelegate.swift
+++ b/Wable-iOS/App/AppDelegate.swift
@@ -15,6 +15,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        injectDependency()
+        
         KakaoSDK.initSDK(appKey: Bundle.kakaoAppKey)
         
         return true

--- a/Wable-iOS/App/AppDelegate.swift
+++ b/Wable-iOS/App/AppDelegate.swift
@@ -27,14 +27,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         configurationForConnecting connectingSceneSession: UISceneSession,
         options: UIScene.ConnectionOptions
     ) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {}
 }

--- a/Wable-iOS/Core/DI/DIContainer.swift
+++ b/Wable-iOS/Core/DI/DIContainer.swift
@@ -37,12 +37,7 @@ extension AppDIContainer: DependencyContainer {
     }
     
     func register<T>(for type: T.Type, _ resolver: @escaping (any DependencyResolvable) -> T) {
-        dependencies[key(type)] = { [weak self] in
-            guard let self else {
-                fatalError("self is optional")
-            }
-            return resolver(self)
-        }
+        dependencies[key(type)] = resolver
     }
     
     func unregister<T>(for type: T.Type) {

--- a/Wable-iOS/Presentation/Overview/Page/View/OverviewPageViewController.swift
+++ b/Wable-iOS/Presentation/Overview/Page/View/OverviewPageViewController.swift
@@ -13,7 +13,12 @@ final class OverviewPageViewController: UIViewController {
     
     // MARK: - Property
     
-    private var currentIndex = 0
+    private var currentIndex = 0 {
+        didSet {
+            guard oldValue != currentIndex else { return }
+            trackPageChangeEvent(for: currentIndex)
+        }
+    }
     private var viewControllers = [UIViewController]()
     
     private let pageViewController = UIPageViewController(
@@ -189,13 +194,26 @@ private extension OverviewPageViewController {
     }
 }
 
-
-
 // MARK: - Helper Method
 
 private extension OverviewPageViewController {
     func index(for viewController: UIViewController) -> Int? {
         return viewControllers.firstIndex(of: viewController)
+    }
+    
+    func trackPageChangeEvent(for index: Int) {
+        switch index {
+        case 0:
+            AmplitudeManager.shared.trackEvent(tag: "click_gameschedule")
+        case 1:
+            AmplitudeManager.shared.trackEvent(tag: "click_ranking")
+        case 2:
+            AmplitudeManager.shared.trackEvent(tag: "click_news")
+        case 3:
+            AmplitudeManager.shared.trackEvent(tag: "click_announcement")
+        default:
+            break
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- DIContainer의 클로저 저장 방식을 수정하였습니다.
- 소식 탭의 세그먼트 변화에 따른 앰플리튜드 태그를 추가하였습니다.

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### DIContainer + Injected 사용 방법
- 앱이 시작 시, 의존성을 컨테이너에 미리 등록해 놓고 사용하는 곳에서 Injected 프로퍼티 래퍼를 통해 간편하게 의존성을 주입할 수 있습니다.
- 필요한 의존성은 반드시 앱 시작 시에 모두 등록해야 합니다.
- 미리 등록하지 않은 타입에 대하여, `resolve()`를 호출하게 되면 `fatalError`가 발생하여 앱이 터지기 때문에 주의해야 합니다.
- App 폴더에 파일(AppDelegate+InjectDependency.swift)를 추가하여 의존성 등록을 할 수 있도록 하였습니다.

<details>
<summary>AppDelegate+InjectDependency.swift</summary>

```swift
import Foundation

extension AppDelegate {
    var diContainer: AppDIContainer { AppDIContainer.shared }
    
    func injectDependency() {
        
        // TODO: 객체를 주입
        
    }
}

// AppDelegate에서는..
@main
class AppDelegate: UIResponder, UIApplicationDelegate {
    func application(
        _ application: UIApplication,
        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
    ) -> Bool {
        injectDependency() // 앱이 시작할 때, 의존성 등록
        
        KakaoSDK.initSDK(appKey: Bundle.kakaoAppKey)
        
        return true
    }
// 생략..
}
```
</details>

- "Repository -> UseCase -> ViewModel -> ViewController"의 의존 관계에서 의존성 등록을 어디까지 할 것인가에 대한 논의가 필요해 보입니다.
- '객체의 생명이 긴가', '테스트를 위한 Mock 객체로 대체할 수 있어야 하는가' 등의 기준을 가지고 의견을 나눠보면 좋을 것 같습니다.
- 아래는 DIContainer와 Injected 사용 예시입니다.

<details>
<summary>DIContainer+Injected 사용 예시</summary>

```swift
import Foundation

// MARK: - DependencyContainer

protocol DependencyRegistable {
    func register<T>(for type: T.Type, object: T)
    func register<T>(for type: T.Type, _ resolver: @escaping (DependencyResolvable) -> T)
    func unregister<T>(for type: T.Type)
}

protocol DependencyResolvable {
    func resolve<T>(for type: T.Type) -> T
}

typealias DependencyContainer = DependencyRegistable & DependencyResolvable

// MARK: - AppDIContainer

final class AppDIContainer {
    static let shared = AppDIContainer()
    
    private var dependencies = [String: Any]()
    
    private init() {}
}

extension AppDIContainer: DependencyContainer {
    func register<T>(for type: T.Type, object: T) {
        dependencies[key(type)] = object
    }
    
    func register<T>(for type: T.Type, _ resolver: @escaping (any DependencyResolvable) -> T) {
        dependencies[key(type)] = resolver
    }
    
    
    func unregister<T>(for type: T.Type) {
        dependencies.removeValue(forKey: key(type))
    }
    
    func resolve<T>(for type: T.Type) -> T {
        let key = key(type)
        
        if let resolver = dependencies[key] as? (any DependencyResolvable) -> T {
            return resolver(self)
        } else if let object = dependencies[key] as? T {
            return object
        } else {
            fatalError("No dependency registered for \(key)")
        }
    }
    
    private func key<T>(_ type: T.Type) -> String {
        return String(describing: type)
    }
}

@propertyWrapper
struct Injected<T> {
    private var dependency: T
    
    init() {
        self.dependency = AppDIContainer.shared.resolve(for: T.self)
    }
    
    var wrappedValue: T {
        get { dependency }
    }
}

struct NetworkService {
    private let session: URLSession
    
    init(session: URLSession = .shared) {
        self.session = session
    }
}

struct Repository {
    private let network: NetworkService
    
    init(network: NetworkService) {
        self.network = network
    }
}

struct UseCase {
    @Injected var repository: Repository // Injected 프로퍼티 래퍼를 사용하여 간단하게 의존성을 주입
    
    init() { // 생성자에서 repository를 주입해야 할 필요 X
        print("객체 생성 완")
    }
}

// 미리 의존성을 등록
func register() {
    AppDIContainer.shared.register(for: NetworkService.self, object: NetworkService())
    
    AppDIContainer.shared.register(for: Repository.self) { resolver in
        let network = resolver.resolve(for: NetworkService.self)
        return Repository(network: network)
    }
}
```
</details>


## 🔗 연결된 이슈
- Resolved: #149


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled automatic tracking of page navigation events to enhance analytics insights.

- **Refactor**
  - Upgraded the app’s launch process with improved dependency setup for smoother initialization.
  - Simplified dependency registration logic to boost overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->