### PR TITLE
[Feat] Combine으로 Driver, Relay, asDriver 구현하기

### DIFF
--- a/Wable-iOS.xcodeproj/project.pbxproj
+++ b/Wable-iOS.xcodeproj/project.pbxproj
@@ -241,6 +241,7 @@
 		DE8E863F2D91A032000A4292 /* AmplitudeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8E863E2D91A032000A4292 /* AmplitudeManager.swift */; };
 		DE8E86432D91A0DA000A4292 /* LookinServer in Frameworks */ = {isa = PBXBuildFile; productRef = DE8E86422D91A0DA000A4292 /* LookinServer */; };
 		DE8FF1912D8155DD00C41880 /* WableButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8FF1902D8155DD00C41880 /* WableButton.swift */; };
+		DE98919D2D994BFF00D538D8 /* Publisher+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE98919C2D994BFF00D538D8 /* Publisher+Driver.swift */; };
 		DE9B94762D927F140060FF92 /* NoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9B94752D927F140060FF92 /* NoticeViewModel.swift */; };
 		DEAFE0512D8C44810097E91C /* GameScheduleListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAFE0502D8C44810097E91C /* GameScheduleListViewController.swift */; };
 		DEAFE0562D8C45980097E91C /* GameScheduleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAFE0552D8C45980097E91C /* GameScheduleCell.swift */; };
@@ -483,6 +484,7 @@
 		DE8E863C2D918759000A4292 /* RankViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankViewModel.swift; sourceTree = "<group>"; };
 		DE8E863E2D91A032000A4292 /* AmplitudeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplitudeManager.swift; sourceTree = "<group>"; };
 		DE8FF1902D8155DD00C41880 /* WableButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WableButton.swift; sourceTree = "<group>"; };
+		DE98919C2D994BFF00D538D8 /* Publisher+Driver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Driver.swift"; sourceTree = "<group>"; };
 		DE9B94752D927F140060FF92 /* NoticeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeViewModel.swift; sourceTree = "<group>"; };
 		DEAFE0502D8C44810097E91C /* GameScheduleListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameScheduleListViewController.swift; sourceTree = "<group>"; };
 		DEAFE0552D8C45980097E91C /* GameScheduleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameScheduleCell.swift; sourceTree = "<group>"; };
@@ -1527,6 +1529,7 @@
 				DDCD66EB2D7DE5D900EF4C28 /* ConstraintMaker+.swift */,
 				DE59BBA82D8A9EFD0040ADCB /* UIViewController+.swift */,
 				DE83891C2D9071E400C089E6 /* Date+.swift */,
+				DE98919C2D994BFF00D538D8 /* Publisher+Driver.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1826,6 +1829,7 @@
 				DE8E863D2D918759000A4292 /* RankViewModel.swift in Sources */,
 				DE8D126A2D859FB000D02993 /* WableBottomSheetController.swift in Sources */,
 				DD2968732D6DAD5F00143851 /* APIProvider.swift in Sources */,
+				DE98919D2D994BFF00D538D8 /* Publisher+Driver.swift in Sources */,
 				DE83891D2D9071E400C089E6 /* Date+.swift in Sources */,
 				DD2968742D6DAD5F00143851 /* NetworkError.swift in Sources */,
 				DD2968432D6DAD2F00143851 /* FetchGameSchedules.swift in Sources */,

--- a/Wable-iOS/Presentation/Helper/Extension/Publisher+Driver.swift
+++ b/Wable-iOS/Presentation/Helper/Extension/Publisher+Driver.swift
@@ -9,6 +9,16 @@ import Combine
 import Foundation
 
 extension Publisher {
+    /**
+     * Publisher를 Driver로 변환합니다.
+     *
+     * - 모든 에러를 주어진 기본값으로 대체합니다.
+     * - 메인 스레드에서 결과를 전달합니다.
+     * - AnyPublisher로 타입을 지웁니다.
+     *
+     * - Parameter defaultValue: 에러 발생 시 대체할 기본값
+     * - Returns: 메인 스레드에서 동작하고 에러가 없는 Driver<Output>
+     */
     func asDriver(onErrorJustReturn defaultValue: Output) -> Driver<Output> {
         return self
             .replaceError(with: defaultValue)
@@ -18,6 +28,14 @@ extension Publisher {
 }
 
 extension Publisher where Failure == Never {
+    /**
+     * 에러가 없는 Publisher를 Driver로 변환합니다.
+     *
+     * - 메인 스레드에서 결과를 전달합니다.
+     * - AnyPublisher로 타입을 지웁니다.
+     *
+     * - Returns: 메인 스레드에서 동작하는 Driver<Output>
+     */
     func asDriver() -> Driver<Output> {
         return self
             .receive(on: DispatchQueue.main)

--- a/Wable-iOS/Presentation/Helper/Extension/Publisher+Driver.swift
+++ b/Wable-iOS/Presentation/Helper/Extension/Publisher+Driver.swift
@@ -1,0 +1,27 @@
+//
+//  Publisher+Driver.swift
+//  Wable-iOS
+//
+//  Created by 김진웅 on 3/30/25.
+//
+
+import Combine
+import Foundation
+
+extension Publisher {
+    func asDriver(onErrorJustReturn defaultValue: Output) -> Driver<Output> {
+        return self
+            .replaceError(with: defaultValue)
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+        
+    }
+}
+
+extension Publisher where Failure == Never {
+    func asDriver() -> Driver<Output> {
+        return self
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+}

--- a/Wable-iOS/Presentation/Helper/Extension/Publisher+Driver.swift
+++ b/Wable-iOS/Presentation/Helper/Extension/Publisher+Driver.swift
@@ -14,7 +14,6 @@ extension Publisher {
             .replaceError(with: defaultValue)
             .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
-        
     }
 }
 

--- a/Wable-iOS/Presentation/Helper/Types.swift
+++ b/Wable-iOS/Presentation/Helper/Types.swift
@@ -19,5 +19,5 @@ typealias Driver<T> = AnyPublisher<T, Never>
 
 // MARK: - Combine PublishRelay & BehaviorRelay
 
-typealias PublishRelay<T> = PassthroughSubject<T, Never>
-typealias BehaviorRelay<T> = CurrentValueSubject<T, Never>
+typealias PassthroughRelay<T> = PassthroughSubject<T, Never>
+typealias CurrentValueRelay<T> = CurrentValueSubject<T, Never>

--- a/Wable-iOS/Presentation/Helper/Types.swift
+++ b/Wable-iOS/Presentation/Helper/Types.swift
@@ -5,9 +5,19 @@
 //  Created by 김진웅 on 3/24/25.
 //
 
+import Combine
 import UIKit
 
 // MARK: - UICollectionView Types
 
 typealias CellRegistration = UICollectionView.CellRegistration
 typealias SupplementaryRegistration = UICollectionView.SupplementaryRegistration
+
+// MARK: - Combine Driver
+
+typealias Driver<T> = AnyPublisher<T, Never>
+
+// MARK: - Combine PublishRelay & BehaviorRelay
+
+typealias PublishRelay<T> = PassthroughSubject<T, Never>
+typealias BehaviorRelay<T> = CurrentValueSubject<T, Never>

--- a/Wable-iOS/Presentation/Overview/Rank/View/RankListViewController.swift
+++ b/Wable-iOS/Presentation/Overview/Rank/View/RankListViewController.swift
@@ -54,8 +54,8 @@ final class RankListViewController: UIViewController {
     
     private let viewModel: ViewModel
     private let cancelBag: CancelBag = .init()
-    private let didLoadSubject = PublishRelay<Void>()
-    private let didRefreshSubject = PublishRelay<Void>()
+    private let didLoadRelay = PassthroughRelay<Void>()
+    private let didRefreshRelay = PassthroughRelay<Void>()
     
     // MARK: - Initializer
 
@@ -82,7 +82,7 @@ final class RankListViewController: UIViewController {
         setupDataSource()
         setupBinding()
         
-        didLoadSubject.send()
+        didLoadRelay.send()
     }
 }
 
@@ -192,8 +192,8 @@ private extension RankListViewController {
     
     func setupBinding() {
         let input = ViewModel.Input(
-            viewDidLoad: didLoadSubject.eraseToAnyPublisher(),
-            viewDidRefresh: didRefreshSubject.eraseToAnyPublisher()
+            viewDidLoad: didLoadRelay.eraseToAnyPublisher(),
+            viewDidRefresh: didRefreshRelay.eraseToAnyPublisher()
         )
         
         let output = viewModel.transform(input: input, cancelBag: cancelBag)
@@ -234,7 +234,7 @@ private extension RankListViewController {
 
 private extension RankListViewController {
     @objc func collectionViewDidRefresh() {
-        didRefreshSubject.send()
+        didRefreshRelay.send()
     }
 }
 

--- a/Wable-iOS/Presentation/Overview/Rank/View/RankListViewController.swift
+++ b/Wable-iOS/Presentation/Overview/Rank/View/RankListViewController.swift
@@ -54,8 +54,8 @@ final class RankListViewController: UIViewController {
     
     private let viewModel: ViewModel
     private let cancelBag: CancelBag = .init()
-    private let didLoadSubject = PassthroughSubject<Void, Never>()
-    private let didRefreshSubject = PassthroughSubject<Void, Never>()
+    private let didLoadSubject = PublishRelay<Void>()
+    private let didRefreshSubject = PublishRelay<Void>()
     
     // MARK: - Initializer
 
@@ -199,14 +199,12 @@ private extension RankListViewController {
         let output = viewModel.transform(input: input, cancelBag: cancelBag)
         
         output.item
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] item in
                 self?.applySnapshot(item: item)
             }
             .store(in: cancelBag)
         
         output.isLoading
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] isLoading in
                 guard !isLoading else { return }
                 self?.collectionView.refreshControl?.endRefreshing()

--- a/Wable-iOS/Presentation/Overview/Rank/ViewModel/RankViewModel.swift
+++ b/Wable-iOS/Presentation/Overview/Rank/ViewModel/RankViewModel.swift
@@ -28,7 +28,7 @@ extension RankViewModel: ViewModelType {
     }
     
     func transform(input: Input, cancelBag: CancelBag) -> Output {
-        let isLoadingSubject = BehaviorRelay<Bool>(false)
+        let isLoadingSubject = CurrentValueRelay<Bool>(false)
         
         let loadTrigger = Publishers.Merge(input.viewDidLoad, input.viewDidRefresh)
         

--- a/Wable-iOS/Presentation/Overview/Rank/ViewModel/RankViewModel.swift
+++ b/Wable-iOS/Presentation/Overview/Rank/ViewModel/RankViewModel.swift
@@ -18,22 +18,19 @@ final class RankViewModel {
 
 extension RankViewModel: ViewModelType {
     struct Input {
-        let viewDidLoad: AnyPublisher<Void, Never>
-        let viewDidRefresh: AnyPublisher<Void, Never>
+        let viewDidLoad: Driver<Void>
+        let viewDidRefresh: Driver<Void>
     }
     
     struct Output {
-        let item: AnyPublisher<RankViewItem, Never>
-        let isLoading: AnyPublisher<Bool, Never>
+        let item: Driver<RankViewItem>
+        let isLoading: Driver<Bool>
     }
     
     func transform(input: Input, cancelBag: CancelBag) -> Output {
-        let isLoadingSubject = CurrentValueSubject<Bool, Never>(false)
+        let isLoadingSubject = BehaviorRelay<Bool>(false)
         
-        let loadTrigger = Publishers.Merge(
-            input.viewDidLoad,
-            input.viewDidRefresh
-        )
+        let loadTrigger = Publishers.Merge(input.viewDidLoad, input.viewDidRefresh)
         
         let fetchGameType = overviewRepository.fetchGameCategory()
             .replaceError(with: "")
@@ -50,22 +47,18 @@ extension RankViewModel: ViewModelType {
             })
             .withUnretained(self)
             .flatMap { owner, _ -> AnyPublisher<RankViewItem, Never> in
-                
-                return Publishers.CombineLatest(
-                    fetchGameType,
-                    fetchRanks
-                )
+                return Publishers.CombineLatest(fetchGameType, fetchRanks)
                 .map { RankViewItem(gameType: $0, ranks: $1) }
                 .eraseToAnyPublisher()
             }
             .handleEvents(receiveOutput: { _ in
                 isLoadingSubject.send(false)
             })
-            .eraseToAnyPublisher()
+            .asDriver()
         
         return Output(
             item: item,
-            isLoading: isLoadingSubject.eraseToAnyPublisher()
+            isLoading: isLoadingSubject.asDriver()
         )
     }
 }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- RxSwift의 Driver, Relay, asDriver를 간접적으로 구현하였습니다.

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### Driver, Relay, asDriver
- 뷰모델과 뷰컨트롤러 간 비동기 이벤트 바인딩에서 Combine 퍼블리셔는 일반적으로 Failure 타입을 Never로 선언합니다.
- 이는 UI 업데이트 과정에서 에러가 발생하더라도 흐름이 중단되지 않고 사용자 이벤트를 지속적으로 처리하기 위함입니다.
- RxSwift에서는 이러한 패턴을 Driver와 Relay라는 특수한 타입으로 추상화했고, 이를 Combine에서도 구현하여 코드의 의도를 명확히 표현하고자 했습니다.
- 또한 AnyPublisher<Output, Never>를 반복적으로 명시하는 것보다 Driver와 같은 의미 있는 타입 이름을 사용함으로써 코드의 가독성과 의도 전달을 개선할 수 있습니다.

#### 주의사항
- `typealias Driver<T> = AnyPublisher<T, Never>`로 정의된 Driver는 타입 수준에서 메인 스레드 실행을 보장하지 않습니다.
- 따라서 항상 `asDriver()` 또는 `asDriver(onErrorJustReturn:)` 메서드를 호출하여 메인 스레드 실행을 보장해야 합니다.

<details>
<summary>Types.swift</summary>

```swift
// MARK: - Combine Driver

typealias Driver<T> = AnyPublisher<T, Never>

// MARK: - Combine PublishRelay & BehaviorRelay

typealias PublishRelay<T> = PassthroughSubject<T, Never>
typealias BehaviorRelay<T> = CurrentValueSubject<T, Never>
```
</details>

<details>
<summary>Publisher+Driver.swift</summary>

```swift
import Combine
import Foundation

extension Publisher {
    func asDriver(onErrorJustReturn defaultValue: Output) -> Driver<Output> {
        return self
            .replaceError(with: defaultValue)
            .receive(on: DispatchQueue.main)
            .eraseToAnyPublisher()
        
    }
}

extension Publisher where Failure == Never {
    func asDriver() -> Driver<Output> {
        return self
            .receive(on: DispatchQueue.main)
            .eraseToAnyPublisher()
    }
}
```
</details>

## 🔗 연결된 이슈
- Resolved: #151 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new utility methods for the `Publisher` type that enhance error handling and integration with the `Driver` type.
  - Added new type aliases for `Driver`, `PassthroughRelay`, and `CurrentValueRelay` to streamline reactive programming.

- **Refactor**
  - Transitioned from Combine to RxSwift for reactive event stream handling, improving data flow and responsiveness in the application.
  - Updated various properties and structures to utilize `Driver` and `Relay` types for better management of event streams.
  - Organized new functionality within the project structure for improved clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->