### PR TITLE
[Fix] UITextField 익스텐션 메서드 수정

### DIFF
--- a/Wable-iOS/Presentation/Helper/Extension/UITextField+.swift
+++ b/Wable-iOS/Presentation/Helper/Extension/UITextField+.swift
@@ -45,8 +45,8 @@ extension UITextField {
     ///
     /// - Parameters:
     ///   - style: UIFont.Pretendard 스타일
-    ///   - text: 초기 텍스트 (선택 사항)
     ///   - placeholder: 플레이스홀더 텍스트 (선택 사항)
+    ///   - text: 초기 텍스트 (선택 사항)
     ///
     /// - 사용 예시:
     /// ```
@@ -56,9 +56,9 @@ extension UITextField {
     ///
     /// - Note: UITextField는 한 줄 텍스트만 지원하므로 baselineOffset과 lineHeight는 적용하지 않습니다.
     convenience init(
-        pretendardStyle style: UIFont.Pretendard,
-        text: String? = nil,
-        placeholder: String? = nil
+        pretendard style: UIFont.Pretendard,
+        placeholder: String? = nil,
+        text: String? = nil
     ) {
         self.init(frame: .zero)
         
@@ -75,12 +75,12 @@ extension UITextField {
         
         self.font = font
         
-        if let text {
-            self.text = text
-        }
-        
         if let placeholder {
             self.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: defaultAttributes)
+        }
+        
+        if let text {
+            self.text = text
         }
     }
     

--- a/Wable-iOS/Presentation/Helper/Extension/UITextField+.swift
+++ b/Wable-iOS/Presentation/Helper/Extension/UITextField+.swift
@@ -36,6 +36,54 @@ extension UITextField {
         self.defaultTextAttributes = attributes
     }
     
+    // MARK: - Pretendard style Initializer
+    
+    /// Pretendard 폰트 스타일을 적용한 UITextField를 생성하는 편의 생성자입니다.
+    ///
+    /// 이 생성자는 `defaultTextAttributes`를 가장 먼저 설정하여 나중에 설정하는
+    /// 다른 속성(textColor, textAlignment 등)이 기존 폰트와 자간 설정을 덮어씌우지 않도록 합니다.
+    ///
+    /// - Parameters:
+    ///   - style: UIFont.Pretendard 스타일
+    ///   - text: 초기 텍스트 (선택 사항)
+    ///   - placeholder: 플레이스홀더 텍스트 (선택 사항)
+    ///
+    /// - 사용 예시:
+    /// ```
+    /// let nameField = UITextField(pretendardStyle: .body1, placeholder: "이름을 입력하세요")
+    /// nameField.textColor = .black // 폰트와 자간 설정은 유지됨
+    /// ```
+    ///
+    /// - Note: UITextField는 한 줄 텍스트만 지원하므로 baselineOffset과 lineHeight는 적용하지 않습니다.
+    convenience init(
+        pretendardStyle style: UIFont.Pretendard,
+        text: String? = nil,
+        placeholder: String? = nil
+    ) {
+        self.init(frame: .zero)
+        
+        let font = UIFont.pretendard(style)
+        
+        // 기본 속성 딕셔너리 생성 (폰트와 자간만 포함)
+        let defaultAttributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .kern: style.kerning
+        ]
+        
+        // 중요: defaultTextAttributes를 가장 먼저 설정하여 다른 속성들이 이를 덮어씌우지 않도록 함
+        self.defaultTextAttributes = defaultAttributes
+        
+        self.font = font
+        
+        if let text {
+            self.text = text
+        }
+        
+        if let placeholder {
+            self.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: defaultAttributes)
+        }
+    }
+    
     // MARK: - addPadding
 
     /// `UITextField`의 왼쪽 및 오른쪽에 패딩을 추가합니다.

--- a/Wable-iOS/Presentation/Helper/Extension/UITextField+.swift
+++ b/Wable-iOS/Presentation/Helper/Extension/UITextField+.swift
@@ -9,33 +9,6 @@ import UIKit
 
 extension UITextField {
     
-    // MARK: - setPretendard
-
-    /// 주어진 `Pretendard` 스타일을 `UITextField`의 기본 텍스트 속성에 적용합니다.
-    ///
-    /// - Parameter style: 적용할 `UIFont.Pretendard` 스타일
-    ///
-    /// 사용 예시:
-    /// ```swift
-    /// let textField = UITextField()
-    /// textField.setPretendard(with: .body1)
-    /// textField.attributedPlaceholder = "Enter your text".pretendardString(with: .body1)
-    /// ```
-    func setPretendard(with style: UIFont.Pretendard) {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.minimumLineHeight = style.lineHeight
-        paragraphStyle.maximumLineHeight = style.lineHeight
-        
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.pretendard(style),
-            .kern: style.kerning,
-            .paragraphStyle: paragraphStyle,
-            .baselineOffset: style.baselineOffset
-        ]
-        
-        self.defaultTextAttributes = attributes
-    }
-    
     // MARK: - Pretendard style Initializer
     
     /// Pretendard 폰트 스타일을 적용한 UITextField를 생성하는 편의 생성자입니다.

--- a/Wable-iOS/Presentation/Onboarding/View/ProfileRegisterView.swift
+++ b/Wable-iOS/Presentation/Onboarding/View/ProfileRegisterView.swift
@@ -39,9 +39,10 @@ final class ProfileRegisterView: UIView {
         $0.configuration?.image = .icProfileplus
     }
     
-    let nickNameTextField: UITextField = UITextField().then {
-        $0.setPretendard(with: .body2)
-        $0.placeholder = "예) 중꺾마"
+    let nickNameTextField: UITextField = UITextField(
+        pretendard: .body2,
+        placeholder: "예) 중꺾마"
+    ).then {
         $0.textColor = .wableBlack
         $0.layer.cornerRadius = 6.adjustedWidth
         $0.backgroundColor = .gray200


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 기존 UITextField의 익스텐션 메서드인 `setPretendard(with:)`를 삭제하고, 편의 생성자를 구현하였습니다.

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 왜 편의생성자인가
- `UITextField`의 `setPretendard(with:)`을 통한 `defaultTextAttributes`를 설정할 때의 문제를 해결하기 위함입니다.

#### 😂 `setPretendard(with:)`의 문제
- 만약 다른 속성을 설정(예: `textColor = .blue`)한 후, `setPretendard(with:)`를 호출하여, `defaultTextAttributes`를 설정하면 이전에 설정한 속성을 덮어씌워버리는 문제가 발생했습니다.

#### 😄 편의 생성자로 `defaultTextAttributes`의 설정 시점을 강제
- 편의 생성자를 통해 객체 생성 초기에 `defaultTextAttributes`를 먼저 설정하여, 이후 속성 설정이 덮어씌워지는 문제가 없도록 하였습니다.

#### 📍 왜 `kerning`만 적용했나요?
- 텍스트필드는 1줄의 내용만을 보여주기 때문에, `lineHeight`와 `baselineOffset`은 불필요하다고 생각하였습니다.

<details>
<summary>UITextField+.swift</summary>

```swift
// MARK: - Pretendard style Initializer

/// Pretendard 폰트 스타일을 적용한 UITextField를 생성하는 편의 생성자입니다.
///
/// 이 생성자는 `defaultTextAttributes`를 가장 먼저 설정하여 나중에 설정하는
/// 다른 속성(textColor, textAlignment 등)이 기존 폰트와 자간 설정을 덮어씌우지 않도록 합니다.
///
/// - Parameters:
///   - style: UIFont.Pretendard 스타일
///   - placeholder: 플레이스홀더 텍스트 (선택 사항)
///   - text: 초기 텍스트 (선택 사항)
///
/// - 사용 예시:
/// ```
/// let nameField = UITextField(pretendardStyle: .body1, placeholder: "이름을 입력하세요")
/// nameField.textColor = .black // 폰트와 자간 설정은 유지됨
/// ```
///
/// - Note: UITextField는 한 줄 텍스트만 지원하므로 baselineOffset과 lineHeight는 적용하지 않습니다.
convenience init(
    pretendard style: UIFont.Pretendard,
    placeholder: String? = nil,
    text: String? = nil
) {
    self.init(frame: .zero)
    
    let font = UIFont.pretendard(style)
    
    // 기본 속성 딕셔너리 생성 (폰트와 자간만 포함)
    let defaultAttributes: [NSAttributedString.Key: Any] = [
        .font: font,
        .kern: style.kerning
    ]
    
    // 중요: defaultTextAttributes를 가장 먼저 설정하여 다른 속성들이 이를 덮어씌우지 않도록 함
    self.defaultTextAttributes = defaultAttributes
    
    self.font = font
    
    if let placeholder {
        self.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: defaultAttributes)
    }
    
    if let text {
        self.text = text
    }
}
```
</details>

## 🔗 연결된 이슈
- Resolved: #159 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated text input fields now showcase a consistent and refined appearance. In the profile registration view, the text field displays an improved placeholder that guides users effectively.

- **Refactor**
  - Streamlined the text field configuration for a more coherent and simplified setup across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->