### PR TITLE
Fix/#171 community registration

### DIFF
--- a/Wable-iOS/Data/Mapper/CommunityMapper.swift
+++ b/Wable-iOS/Data/Mapper/CommunityMapper.swift
@@ -23,7 +23,7 @@ extension CommunityMapper {
     }
     
     static func toDomain(_ response: DTO.Response.IsUserRegistered) -> CommunityRegistration {
-        guard let teamName = response.commnunityName else {
+        guard let teamName = response.communityName else {
             return CommunityRegistration(team: nil, hasRegisteredTeam: false)
         }
         

--- a/Wable-iOS/Infra/Network/DTO/Response/Community/IsUserRegistered.swift
+++ b/Wable-iOS/Infra/Network/DTO/Response/Community/IsUserRegistered.swift
@@ -11,6 +11,10 @@ import Foundation
 
 extension DTO.Response {
     struct IsUserRegistered: Decodable {
-        let commnunityName: String?
+        let communityName: String?
+        
+        enum CodingKeys: String, CodingKey {
+            case communityName = "community"
+        }
     }
 }

--- a/Wable-iOS/Presentation/Community/View/Cell/CommunityInviteCell.swift
+++ b/Wable-iOS/Presentation/Community/View/Cell/CommunityInviteCell.swift
@@ -68,7 +68,7 @@ final class CommunityInviteCell: UICollectionViewCell {
         titleLabel.text = title
         
         progressBar.progressTintColor = progressBarColor
-        progressBar.setProgress(progress, animated: true)
+        progressBar.setProgress(progress, animated: false)
     }
 }
 

--- a/Wable-iOS/Presentation/Community/View/CommunityViewController.swift
+++ b/Wable-iOS/Presentation/Community/View/CommunityViewController.swift
@@ -169,6 +169,7 @@ private extension CommunityViewController {
         output.completeRegistration
             .compactMap { $0 }
             .sink { [weak self] team in
+                self?.scrollToTopItem()
                 self?.showCompleteSheet(for: team.rawValue)
             }
             .store(in: cancelBag)
@@ -245,6 +246,17 @@ private extension CommunityViewController {
     
     func copyLinkToClipboard() {
         UIPasteboard.general.string = Constant.littlyURLText
+    }
+    
+    func scrollToTopItem() {
+        guard collectionView.numberOfSections > 0,
+                collectionView.numberOfItems(inSection: 0) > 0
+        else {
+            return
+        }
+        
+        let indexPath = IndexPath(item: 0, section: 0)
+        collectionView.scrollToItem(at: indexPath, at: .top, animated: true)
     }
 }
 


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 사전 신청 후, 앱 재시작 시 기존의 내용을 반영하지 못하는 문제를 해결하였습니다. (원인은 오타,,)
- 사전 신청 후의 UI를 개선하였습니다. (애니메이션 추가)

|    구현 내용    |   IPhone 13 mini   |
| :-------------: | :----------: |
| 사전 신청 후 UI 개선 | <img src = "https://github.com/user-attachments/assets/6cfbdbb1-4726-425d-bf1d-625f869b674b" width ="250"> |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 오타로 인한 에러임에도, 필드 자체가 옵셔널 타입이기 때문에 디코딩 에러로 처리되지 못하고, `nil`로 할당되었었더라고요. 이것을 해결할 수 있는 방법이 있을지 궁금합니다.

## 🔗 연결된 이슈
- Resolved: #171
