### PR TITLE
[Chore] 커스텀 네비게이션 바의 애니메이션뷰 높이, 위치 수정

### DIFF
--- a/Wable-iOS/Presentation/WableComponent/Navigation/NavigationView.swift
+++ b/Wable-iOS/Presentation/WableComponent/Navigation/NavigationView.swift
@@ -5,10 +5,11 @@
 //  Created by YOUJIM on 3/9/25.
 //
 
-
 import UIKit
 
 import Lottie
+import SnapKit
+import Then
 
 // MARK: - Navigation Types
 
@@ -159,8 +160,9 @@ private extension NavigationView {
         }
         
         homeUnderLineView.snp.makeConstraints {
-            $0.bottom.horizontalEdges.equalToSuperview()
-            $0.adjustedHeightEqualTo(2)
+            $0.bottom.equalToSuperview().offset(2)
+            $0.horizontalEdges.equalToSuperview()
+            $0.adjustedHeightEqualTo(4)
         }
         
         pageUnderLineView.snp.makeConstraints {


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 커스텀 네비게이션바인 NavigationView의 로티 애니메이션 바의 높이와 위치를 수정하였습니다.

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| Before | <img src = "https://github.com/user-attachments/assets/b31615f9-7040-4222-93fc-d3c158f95340"> |
| After | <img src = "https://github.com/user-attachments/assets/d3697448-3193-44e8-8e55-4ba52454cdc3"> |

## 🔗 연결된 이슈
- Resolved: #173


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the position and height of the underline in the navigation view for improved visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->