### PR TITLE
[Feat] 세부 화면 기능 구현

### DIFF
--- a/Wable-iOS.xcodeproj/project.pbxproj
+++ b/Wable-iOS.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		DD8326962D95836F0014B62D /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8326952D95836B0014B62D /* HomeViewModel.swift */; };
 		DD8B42A42DA15DB0007DC1CA /* UITextView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8B42A32DA15DA9007DC1CA /* UITextView+.swift */; };
 		DD8B42A82DA16B1F007DC1CA /* HomeDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8B42A72DA16B1A007DC1CA /* HomeDetailViewModel.swift */; };
+		DD90EEA82DC40D1800338EB2 /* FetchGhostUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD90EEA72DC40D1700338EB2 /* FetchGhostUseCase.swift */; };
 		DD9980DB2D834CA900EBBFBC /* CommentInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9980DA2D834CA900EBBFBC /* CommentInfo.swift */; };
 		DD9980DF2D834F4E00EBBFBC /* CommentCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9980DC2D834F4E00EBBFBC /* CommentCollectionViewCell.swift */; };
 		DD9980E02D834F4E00EBBFBC /* PostUserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9980DE2D834F4E00EBBFBC /* PostUserInfoView.swift */; };
@@ -453,6 +454,7 @@
 		DD8CEF472D6A007900DBE580 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DD8CEF482D6A007900DBE580 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		DD8CEFF82D6A00BB00DBE580 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = "Base.lproj/LaunchScreen 2.storyboard"; sourceTree = "<group>"; };
+		DD90EEA72DC40D1700338EB2 /* FetchGhostUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchGhostUseCase.swift; sourceTree = "<group>"; };
 		DD9980DA2D834CA900EBBFBC /* CommentInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentInfo.swift; sourceTree = "<group>"; };
 		DD9980DC2D834F4E00EBBFBC /* CommentCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentCollectionViewCell.swift; sourceTree = "<group>"; };
 		DD9980DD2D834F4E00EBBFBC /* ContentCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -1161,6 +1163,7 @@
 		DD9EAE202D99C58600803A1A /* Home */ = {
 			isa = PBXGroup;
 			children = (
+				DD90EEA72DC40D1700338EB2 /* FetchGhostUseCase.swift */,
 				DD5098192DA519C600F666DE /* FetchUserInformationUseCase.swift */,
 				DD5098132DA2C35C00F666DE /* DeleteCommentLikedUseCase.swift */,
 				DD5098112DA2C34900F666DE /* CreateCommentLikedUseCase.swift */,
@@ -2121,6 +2124,7 @@
 				DD2968462D6DAD2F00143851 /* FetchAccountInfo.swift in Sources */,
 				DD2968472D6DAD2F00143851 /* FetchContent.swift in Sources */,
 				DD2968482D6DAD2F00143851 /* FetchNotificationNumber.swift in Sources */,
+				DD90EEA82DC40D1800338EB2 /* FetchGhostUseCase.swift in Sources */,
 				DD2968492D6DAD2F00143851 /* FetchContents.swift in Sources */,
 				DD5098102DA2C1C500F666DE /* DeleteCommentUseCase.swift in Sources */,
 				DD29684A2D6DAD2F00143851 /* FetchLCKTeamRankings.swift in Sources */,

--- a/Wable-iOS.xcodeproj/project.pbxproj
+++ b/Wable-iOS.xcodeproj/project.pbxproj
@@ -159,6 +159,8 @@
 		DD8B42A42DA15DB0007DC1CA /* UITextView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8B42A32DA15DA9007DC1CA /* UITextView+.swift */; };
 		DD8B42A82DA16B1F007DC1CA /* HomeDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8B42A72DA16B1A007DC1CA /* HomeDetailViewModel.swift */; };
 		DD90EEA82DC40D1800338EB2 /* FetchGhostUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD90EEA72DC40D1700338EB2 /* FetchGhostUseCase.swift */; };
+		DD90EEAB2DC5F66900338EB2 /* CreateBannedUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD90EEAA2DC5F65100338EB2 /* CreateBannedUseCase.swift */; };
+		DD90EEAD2DC5F6CC00338EB2 /* CreateReportUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD90EEAC2DC5F6BB00338EB2 /* CreateReportUseCase.swift */; };
 		DD9980DB2D834CA900EBBFBC /* CommentInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9980DA2D834CA900EBBFBC /* CommentInfo.swift */; };
 		DD9980DF2D834F4E00EBBFBC /* CommentCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9980DC2D834F4E00EBBFBC /* CommentCollectionViewCell.swift */; };
 		DD9980E02D834F4E00EBBFBC /* PostUserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9980DE2D834F4E00EBBFBC /* PostUserInfoView.swift */; };
@@ -455,6 +457,8 @@
 		DD8CEF482D6A007900DBE580 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		DD8CEFF82D6A00BB00DBE580 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = "Base.lproj/LaunchScreen 2.storyboard"; sourceTree = "<group>"; };
 		DD90EEA72DC40D1700338EB2 /* FetchGhostUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchGhostUseCase.swift; sourceTree = "<group>"; };
+		DD90EEAA2DC5F65100338EB2 /* CreateBannedUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateBannedUseCase.swift; sourceTree = "<group>"; };
+		DD90EEAC2DC5F6BB00338EB2 /* CreateReportUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateReportUseCase.swift; sourceTree = "<group>"; };
 		DD9980DA2D834CA900EBBFBC /* CommentInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentInfo.swift; sourceTree = "<group>"; };
 		DD9980DC2D834F4E00EBBFBC /* CommentCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentCollectionViewCell.swift; sourceTree = "<group>"; };
 		DD9980DD2D834F4E00EBBFBC /* ContentCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -1163,6 +1167,8 @@
 		DD9EAE202D99C58600803A1A /* Home */ = {
 			isa = PBXGroup;
 			children = (
+				DD90EEAC2DC5F6BB00338EB2 /* CreateReportUseCase.swift */,
+				DD90EEAA2DC5F65100338EB2 /* CreateBannedUseCase.swift */,
 				DD90EEA72DC40D1700338EB2 /* FetchGhostUseCase.swift */,
 				DD5098192DA519C600F666DE /* FetchUserInformationUseCase.swift */,
 				DD5098132DA2C35C00F666DE /* DeleteCommentLikedUseCase.swift */,
@@ -2082,6 +2088,7 @@
 				DD2968322D6DAD1700143851 /* ContentRepositoryImpl.swift in Sources */,
 				DDCD66EC2D7DE5E000EF4C28 /* ConstraintMaker+.swift in Sources */,
 				DEAFE0512D8C44810097E91C /* GameScheduleListViewController.swift in Sources */,
+				DD90EEAB2DC5F66900338EB2 /* CreateBannedUseCase.swift in Sources */,
 				DE7C530C2D761DCA00076E5D /* ViewModelType.swift in Sources */,
 				DDCD66EA2D7DD72F00EF4C28 /* LottieType.swift in Sources */,
 				DD29683B2D6DAD2F00143851 /* CreateAccountResponse.swift in Sources */,
@@ -2202,6 +2209,7 @@
 				DE3390352D8EF40B00638BB4 /* AnnouncementDetailViewController.swift in Sources */,
 				DDCD66FD2D7DF6D900EF4C28 /* ProfileViewController.swift in Sources */,
 				DEE5D6132D9126D8009E5A25 /* WableBadgeSegmentedControl.swift in Sources */,
+				DD90EEAD2DC5F6CC00338EB2 /* CreateReportUseCase.swift in Sources */,
 				DD005BAB2D80071E00B1661F /* CommentButton.swift in Sources */,
 				DEAFE05B2D8C4E930097E91C /* GameScheduleHeaderView.swift in Sources */,
 				DE7C53182D761F3A00076E5D /* ReuseIdentifiable.swift in Sources */,

--- a/Wable-iOS/Domain/Entity/Opacity.swift
+++ b/Wable-iOS/Domain/Entity/Opacity.swift
@@ -68,4 +68,12 @@ struct Opacity: Hashable {
             value -= 1
         }
     }
+    
+    func reduced() -> Opacity {
+        var newValue = value
+        if newValue > Self.minValue {
+            newValue -= 1
+        }
+        return Opacity(value: newValue)
+    }
 }

--- a/Wable-iOS/Domain/UseCase/Home/CreateBannedUseCase.swift
+++ b/Wable-iOS/Domain/UseCase/Home/CreateBannedUseCase.swift
@@ -1,0 +1,26 @@
+//
+//  CreateBannedUseCase.swift
+//  Wable-iOS
+//
+//  Created by YOUJIM on 5/3/25.
+//
+
+
+import Combine
+import Foundation
+
+final class CreateBannedUseCase {
+    private let repository: ReportRepository
+    
+    init(repository: ReportRepository) {
+        self.repository = repository
+    }
+}
+
+// MARK: - Extension
+
+extension CreateBannedUseCase {
+    func execute(memberID: Int, triggerType: TriggerType.Ban, triggerID: Int) -> AnyPublisher<Void, WableError> {
+        return repository.createBan(memberID: memberID, triggerType: triggerType, triggerID: triggerID)
+    }
+}

--- a/Wable-iOS/Domain/UseCase/Home/CreateReportUseCase.swift
+++ b/Wable-iOS/Domain/UseCase/Home/CreateReportUseCase.swift
@@ -1,0 +1,26 @@
+//
+//  CreateReportUseCase.swift
+//  Wable-iOS
+//
+//  Created by YOUJIM on 5/3/25.
+//
+
+
+import Combine
+import Foundation
+
+final class CreateReportUseCase {
+    private let repository: ReportRepository
+    
+    init(repository: ReportRepository) {
+        self.repository = repository
+    }
+}
+
+// MARK: - Extension
+
+extension CreateReportUseCase {
+    func execute(nickname: String, text: String) -> AnyPublisher<Void, WableError> {
+        return repository.createReport(nickname: nickname, text: text)
+    }
+}

--- a/Wable-iOS/Domain/UseCase/Home/FetchGhostUseCase.swift
+++ b/Wable-iOS/Domain/UseCase/Home/FetchGhostUseCase.swift
@@ -1,0 +1,31 @@
+//
+//  FetchGhostUseCase.swift
+//  Wable-iOS
+//
+//  Created by YOUJIM on 5/2/25.
+//
+
+
+import Combine
+import Foundation
+
+final class FetchGhostUseCase {
+    private let repository: GhostRepository
+    
+    init(repository: GhostRepository) {
+        self.repository = repository
+    }
+}
+
+// MARK: - Extension
+
+extension FetchGhostUseCase {
+    func execute(type: PostType, targetID: Int, userID: Int) -> AnyPublisher<Void, WableError> {
+        return repository.postGhostReduction(
+            alarmTriggerType: type == .comment ? "commentGhost" : "contentGhost",
+            alarmTriggerID: targetID,
+            targetMemberID: userID,
+            reason: ""
+        )
+    }
+}

--- a/Wable-iOS/Presentation/Home/View/HomeDetailViewController.swift
+++ b/Wable-iOS/Presentation/Home/View/HomeDetailViewController.swift
@@ -193,13 +193,7 @@ private extension HomeDetailViewController {
                                 let viewController = WableSheetViewController(title: "게시글을 삭제하시겠어요?", message: "게시글이 영구히 삭제됩니다.")
                                 
                                 viewController.addActions(
-                                    WableSheetAction(
-                                        title: "취소",
-                                        style: .gray,
-                                        handler: {
-                                            viewController.dismiss(animated: true)
-                                        }
-                                    ),
+                                    WableSheetAction(title: "취소", style: .gray),
                                     WableSheetAction(
                                         title: "삭제하기",
                                         style: .primary,
@@ -220,13 +214,7 @@ private extension HomeDetailViewController {
                                 let viewController = WableSheetViewController(title: "신고하시겠어요?")
                                 
                                 viewController.addActions(
-                                    WableSheetAction(
-                                        title: "취소",
-                                        style: .gray,
-                                        handler: {
-                                            viewController.dismiss(animated: true)
-                                        }
-                                    ),
+                                    WableSheetAction(title: "취소", style: .gray),
                                     WableSheetAction(
                                         title: "신고하기",
                                         style: .primary,
@@ -250,13 +238,7 @@ private extension HomeDetailViewController {
                                 let viewController = WableSheetViewController(title: "신고하시겠어요?")
                                 
                                 viewController.addActions(
-                                    WableSheetAction(
-                                        title: "취소",
-                                        style: .gray,
-                                        handler: {
-                                            viewController.dismiss(animated: true)
-                                        }
-                                    ),
+                                    WableSheetAction(title: "취소", style: .gray),
                                     WableSheetAction(
                                         title: "신고하기",
                                         style: .primary,
@@ -285,13 +267,7 @@ private extension HomeDetailViewController {
                     let viewController = WableSheetViewController(title: "와블의 온화한 문화를 해치는\n누군가를 발견하신 건가요?")
                     
                     viewController.addActions(
-                        WableSheetAction(
-                            title: "고민할게요",
-                            style: .gray,
-                            handler: {
-                                viewController.dismiss(animated: true)
-                            }
-                        ),
+                        WableSheetAction(title: "고민할게요", style: .gray),
                         WableSheetAction(
                             title: "네 맞아요",
                             style: .primary,

--- a/Wable-iOS/Presentation/Home/View/HomeDetailViewController.swift
+++ b/Wable-iOS/Presentation/Home/View/HomeDetailViewController.swift
@@ -187,8 +187,18 @@ private extension HomeDetailViewController {
                 postType: .mine,
                 cellType: .detail,
                 likeButtonTapHandler: {
-                self.didContentHeartTappedSubject.send(cell.likeButton.isLiked)
-            })
+                    self.didContentHeartTappedSubject.send(cell.likeButton.isLiked)
+                },
+                settingButtonTapHandler: {
+                    
+                },
+                profileImageViewTapHandler: {
+                    
+                },
+                ghostButtonTapHandler: {
+                    
+                }
+            )
             
             cell.commentButton.addAction(UIAction(handler: { _ in
                 self.didCommentTappedSubject.send()

--- a/Wable-iOS/Presentation/Home/View/HomeViewController.swift
+++ b/Wable-iOS/Presentation/Home/View/HomeViewController.swift
@@ -165,23 +165,24 @@ private extension HomeViewController {
     }
     
     func setupDataSource() {
-        let homeCellRegistration = CellRegistration<ContentCollectionViewCell, Content> { [weak self] cell, indexPath, itemID in
+        let homeCellRegistration = CellRegistration<ContentCollectionViewCell, Content> { [weak self] cell, indexPath, item in
             guard let self = self else { return }
             
             cell.configureCell(
-                info: itemID.content.contentInfo,
-                postType: itemID.content.contentInfo.author.id == self.activeUserID ? .mine : .others,
+                info: item.content.contentInfo,
+                authorType: item.content.contentInfo.author.id == self.activeUserID ? .mine : .others,
                 cellType: .list,
                 likeButtonTapHandler: {
-                    self.didHeartTappedSubject.send((itemID.content.id, cell.likeButton.isLiked))
+                    self.didHeartTappedSubject.send((item.content.id, cell.likeButton.isLiked))
                 },
                 settingButtonTapHandler: {
                     let viewController = WableBottomSheetController()
                     
-                    if self.activeUserID == itemID.content.contentInfo.author.id {
+                    if self.activeUserID == item.content.contentInfo.author.id {
                         viewController.addActions(WableBottomSheetAction(title: "삭제하기", handler: {
                             viewController.dismiss(animated: true, completion: {
                                 let viewController = WableSheetViewController(title: "게시글을 삭제하시겠어요?", message: "게시글이 영구히 삭제됩니다.")
+                                
                                 viewController.addActions(
                                     WableSheetAction(
                                         title: "취소",
@@ -195,7 +196,7 @@ private extension HomeViewController {
                                         style: .primary,
                                         handler: {
                                             viewController.dismiss(animated: true, completion: {
-                                                self.didDeleteTappedSubject.send(itemID.content.id)
+                                                self.didDeleteTappedSubject.send(item.content.id)
                                             })
                                         }
                                     )
@@ -208,6 +209,7 @@ private extension HomeViewController {
                         viewController.addActions(WableBottomSheetAction(title: "신고하기", handler: {
                             viewController.dismiss(animated: true, completion: {
                                 let viewController = WableSheetViewController(title: "신고하시겠어요?")
+                                
                                 viewController.addActions(
                                     WableSheetAction(
                                         title: "취소",
@@ -221,7 +223,7 @@ private extension HomeViewController {
                                         style: .primary,
                                         handler: {
                                             viewController.dismiss(animated: true, completion: {
-                                                self.didReportTappedSubject.send((itemID.content.contentInfo.title, itemID.content.contentInfo.text))
+                                                self.didReportTappedSubject.send((item.content.contentInfo.author.nickname, item.content.contentInfo.text))
                                             })
                                         }
                                     )
@@ -230,13 +232,14 @@ private extension HomeViewController {
                                 self.present(viewController, animated: true)
                             })
                         }), WableBottomSheetAction(title: "밴하기", handler: {
-                            self.didBannedTappedSubject.send((itemID.content.contentInfo.author.id, itemID.content.id))
+                            self.didBannedTappedSubject.send((item.content.contentInfo.author.id, item.content.id))
                         })
                         )
                     } else {
                         viewController.addActions(WableBottomSheetAction(title: "신고하기", handler: {
                             viewController.dismiss(animated: true, completion: {
                                 let viewController = WableSheetViewController(title: "신고하시겠어요?")
+                                
                                 viewController.addActions(
                                     WableSheetAction(
                                         title: "취소",
@@ -250,7 +253,7 @@ private extension HomeViewController {
                                         style: .primary,
                                         handler: {
                                             viewController.dismiss(animated: true, completion: {
-                                                self.didReportTappedSubject.send((itemID.content.contentInfo.title, itemID.content.contentInfo.text))
+                                                self.didReportTappedSubject.send((item.content.contentInfo.author.nickname, item.content.contentInfo.text))
                                             })
                                         }
                                     )
@@ -271,6 +274,7 @@ private extension HomeViewController {
                 },
                 ghostButtonTapHandler: {
                     let viewController = WableSheetViewController(title: "와블의 온화한 문화를 해치는\n누군가를 발견하신 건가요?")
+                    
                     viewController.addActions(
                         WableSheetAction(
                             title: "고민할게요",
@@ -284,7 +288,7 @@ private extension HomeViewController {
                             style: .primary,
                             handler: {
                                 viewController.dismiss(animated: true, completion: {
-                                    self.didGhostTappedSubject.send((itemID.content.id, itemID.content.contentInfo.author.id))
+                                    self.didGhostTappedSubject.send((item.content.id, item.content.contentInfo.author.id))
                                 })
                             }
                         )

--- a/Wable-iOS/Presentation/Home/View/HomeViewController.swift
+++ b/Wable-iOS/Presentation/Home/View/HomeViewController.swift
@@ -171,7 +171,10 @@ private extension HomeViewController {
                     
                 },
                 profileImageViewTapHandler: {
+                    // TODO: 프로필 구현되는 대로 추가적인 설정 필요
+                    let viewController = ProfileViewController()
                     
+                    self.navigationController?.pushViewController(viewController, animated: true)
                 },
                 ghostButtonTapHandler: {
                     

--- a/Wable-iOS/Presentation/Home/View/HomeViewController.swift
+++ b/Wable-iOS/Presentation/Home/View/HomeViewController.swift
@@ -161,7 +161,6 @@ private extension HomeViewController {
     
     func setupDataSource() {
         let homeCellRegistration = CellRegistration<ContentCollectionViewCell, Content> { cell, indexPath, itemID in
-            
             cell.configureCell(
                 info: itemID.content.contentInfo,
                 postType: itemID.content.contentInfo.author.id == self.activeUserID ? .mine : .others,
@@ -179,7 +178,27 @@ private extension HomeViewController {
                     self.navigationController?.pushViewController(viewController, animated: true)
                 },
                 ghostButtonTapHandler: {
+                    let viewController = WableSheetViewController(title: "와블의 온화한 문화를 해치는\n누군가를 발견하신 건가요?")
+                    viewController.addActions(
+                        WableSheetAction(
+                            title: "고민할게요",
+                            style: .gray,
+                            handler: {
+                                viewController.dismiss(animated: true)
+                            }
+                        ),
+                        WableSheetAction(
+                            title: "네 맞아요",
+                            style: .primary,
+                            handler: {
+                                viewController.dismiss(animated: true, completion: {
+                                    // TODO: 뷰모델 send 필요
+                                })
+                            }
+                        )
+                    )
                     
+                    self.present(viewController, animated: true)
                 }
             )
         }

--- a/Wable-iOS/Presentation/Home/View/HomeViewController.swift
+++ b/Wable-iOS/Presentation/Home/View/HomeViewController.swift
@@ -32,6 +32,7 @@ final class HomeViewController: NavigationViewController {
     private let didRefreshSubject = PassthroughSubject<Void, Never>()
     private let didSelectedSubject = PassthroughSubject<Int, Never>()
     private let didHeartTappedSubject = PassthroughSubject<(Int, Bool), Never>()
+    private let didGhostTappedSubject = PassthroughSubject<(Int, Int), Never>()
     private let willDisplayLastItemSubject = PassthroughSubject<Void, Never>()
     private let cancelBag: CancelBag
     
@@ -160,7 +161,9 @@ private extension HomeViewController {
     }
     
     func setupDataSource() {
-        let homeCellRegistration = CellRegistration<ContentCollectionViewCell, Content> { cell, indexPath, itemID in
+        let homeCellRegistration = CellRegistration<ContentCollectionViewCell, Content> { [weak self] cell, indexPath, itemID in
+            guard let self = self else { return }
+            
             cell.configureCell(
                 info: itemID.content.contentInfo,
                 postType: itemID.content.contentInfo.author.id == self.activeUserID ? .mine : .others,
@@ -192,7 +195,7 @@ private extension HomeViewController {
                             style: .primary,
                             handler: {
                                 viewController.dismiss(animated: true, completion: {
-                                    // TODO: 뷰모델 send 필요
+                                    self.didGhostTappedSubject.send((itemID.content.id, itemID.content.contentInfo.author.id))
                                 })
                             }
                         )
@@ -238,6 +241,7 @@ private extension HomeViewController {
             viewDidRefresh: didRefreshSubject.eraseToAnyPublisher(),
             didSelectedItem: didSelectedSubject.eraseToAnyPublisher(),
             didHeartTappedItem: didHeartTappedSubject.eraseToAnyPublisher(),
+            didGhostTappedItem: didGhostTappedSubject.eraseToAnyPublisher(),
             willDisplayLastItem: willDisplayLastItemSubject.eraseToAnyPublisher()
         )
         

--- a/Wable-iOS/Presentation/Home/View/HomeViewController.swift
+++ b/Wable-iOS/Presentation/Home/View/HomeViewController.swift
@@ -128,7 +128,6 @@ private extension HomeViewController {
     func setupView() {
         navigationController?.navigationBar.isHidden = true
         
-        
         view.addSubviews(
             collectionView,
             plusButton,
@@ -159,9 +158,25 @@ private extension HomeViewController {
     
     func setupDataSource() {
         let homeCellRegistration = CellRegistration<ContentCollectionViewCell, Content> { cell, indexPath, itemID in
-            cell.configureCell(info: itemID.content.contentInfo, postType: .mine, likeButtonTapHandler: {
-                self.didHeartTappedSubject.send((itemID.content.id, cell.likeButton.isLiked))
-            })
+            
+            cell.configureCell(
+                info: itemID.content.contentInfo,
+                // TODO: 작성자 구분 필요
+                postType: .mine,
+                cellType: .list,
+                likeButtonTapHandler: {
+                    self.didHeartTappedSubject.send((itemID.content.id, cell.likeButton.isLiked))
+                },
+                settingButtonTapHandler: {
+                    
+                },
+                profileImageViewTapHandler: {
+                    
+                },
+                ghostButtonTapHandler: {
+                    
+                }
+            )
         }
         
         dataSource = DataSource(collectionView: collectionView) { collectionView, indexPath, item in

--- a/Wable-iOS/Presentation/Home/View/HomeViewController.swift
+++ b/Wable-iOS/Presentation/Home/View/HomeViewController.swift
@@ -369,13 +369,25 @@ private extension HomeViewController {
                         contentID: content.content.id,
                         contentTitle: content.content.contentInfo.title,
                         fetchContentInfoUseCase: FetchContentInfoUseCase(repository: ContentRepositoryImpl()),
-                        createContentLikedUseCase: CreateContentLikedUseCase(repository: ContentLikedRepositoryImpl()),
-                        deleteContentLikedUseCase: DeleteContentLikedUseCase(repository: ContentLikedRepositoryImpl()),
                         fetchContentCommentListUseCase: FetchContentCommentListUseCase(repository: CommentRepositoryImpl()),
                         createCommentUseCase: CreateCommentUseCase(repository: CommentRepositoryImpl()),
                         deleteCommentUseCase: DeleteCommentUseCase(repository: CommentRepositoryImpl()),
+                        createContentLikedUseCase: CreateContentLikedUseCase(repository: ContentLikedRepositoryImpl()),
+                        deleteContentLikedUseCase: DeleteContentLikedUseCase(repository: ContentLikedRepositoryImpl()),
                         createCommentLikedUseCase: CreateCommentLikedUseCase(repository: CommentLikedRepositoryImpl()),
-                        deleteCommentLikedUseCase: DeleteCommentLikedUseCase(repository: CommentLikedRepositoryImpl())
+                        deleteCommentLikedUseCase: DeleteCommentLikedUseCase(repository: CommentLikedRepositoryImpl()),
+                        fetchUserInformationUseCase: FetchUserInformationUseCase(
+                            repository: UserSessionRepositoryImpl(
+                                userDefaults: UserDefaultsStorage(
+                                    jsonEncoder: JSONEncoder(),
+                                    jsonDecoder: JSONDecoder()
+                                )
+                            )
+                        ),
+                        fetchGhostUseCase: FetchGhostUseCase(repository: GhostRepositoryImpl()),
+                        createReportUseCase: CreateReportUseCase(repository: ReportRepositoryImpl()),
+                        createBannedUseCase: CreateBannedUseCase(repository: ReportRepositoryImpl()),
+                        deleteContentUseCase: DeleteContentUseCase(repository: ContentRepositoryImpl())
                     ),
                     cancelBag: CancelBag()
                 )

--- a/Wable-iOS/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/Wable-iOS/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -198,10 +198,11 @@ extension HomeViewModel: ViewModelType {
                     .map { _ in id.1 }
                     .asDriver(onErrorJustReturn: id.1)
             }
-            .sink(receiveValue: { userID in
+            .compactMap { userID in
+                return contentsSubject.value.firstIndex(where: { $0.content.contentInfo.author.id == userID })
+            }
+            .sink(receiveValue: { index in
                 var updatedContents = contentsSubject.value
-                
-                guard let index = updatedContents.firstIndex(where: { $0.content.contentInfo.author.id == userID }) else { return }
                 
                 let content = updatedContents[index]
                 let contentInfo = content.content.contentInfo
@@ -238,10 +239,11 @@ extension HomeViewModel: ViewModelType {
                     .map { _ in id }
                     .asDriver(onErrorJustReturn: id)
             }
-            .sink(receiveValue: { contentID in
+            .compactMap { contentID in
+                return contentsSubject.value.firstIndex(where: { $0.content.id == contentID })
+            }
+            .sink(receiveValue: { index in
                 var updatedContents = contentsSubject.value
-                
-                guard let index = updatedContents.firstIndex(where: { $0.content.id == contentID }) else { return }
                 
                 updatedContents.remove(at: index)
                 contentsSubject.send(updatedContents)
@@ -266,10 +268,11 @@ extension HomeViewModel: ViewModelType {
                     .map { _ in content.0 }
                     .asDriver(onErrorJustReturn: -1)
             }
-            .sink(receiveValue: { userID in
+            .compactMap { userID in
+                return contentsSubject.value.firstIndex(where: { $0.content.contentInfo.author.id == userID })
+            }
+            .sink(receiveValue: { index in
                 var updatedContents = contentsSubject.value
-                
-                guard let index = updatedContents.firstIndex(where: { $0.content.contentInfo.author.id == userID }) else { return }
                 
                 let content = updatedContents[index]
                 let contentInfo = content.content.contentInfo

--- a/Wable-iOS/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/Wable-iOS/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -153,6 +153,9 @@ extension HomeViewModel: ViewModelType {
                     ),
                     isDeleted: originalContent.isDeleted
                 )
+                
+                updatedContents[index] = updatedContent
+                contentsSubject.send(updatedContents)
             })
             .store(in: cancelBag)
 

--- a/Wable-iOS/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/Wable-iOS/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -15,19 +15,28 @@ final class HomeViewModel {
     private let deleteContentLikedUseCase: DeleteContentLikedUseCase
     private let fetchUserInformationUseCase: FetchUserInformationUseCase
     private let fetchGhostUseCase: FetchGhostUseCase
+    private let createReportUseCase: CreateReportUseCase
+    private let createBannedUseCase: CreateBannedUseCase
+    private let deleteContentUseCase: DeleteContentUseCase
     
     init(
         fetchContentListUseCase: FetchContentListUseCase,
         createContentLikedUseCase: CreateContentLikedUseCase,
         deleteContentLikedUseCase: DeleteContentLikedUseCase,
         fetchUserInformationUseCase: FetchUserInformationUseCase,
-        fetchGhostUseCase: FetchGhostUseCase
+        fetchGhostUseCase: FetchGhostUseCase,
+        createReportUseCase: CreateReportUseCase,
+        createBannedUseCase: CreateBannedUseCase,
+        deleteContentUseCase: DeleteContentUseCase
     ) {
         self.fetchContentListUseCase = fetchContentListUseCase
         self.createContentLikedUseCase = createContentLikedUseCase
         self.deleteContentLikedUseCase = deleteContentLikedUseCase
         self.fetchUserInformationUseCase = fetchUserInformationUseCase
         self.fetchGhostUseCase = fetchGhostUseCase
+        self.createReportUseCase = createReportUseCase
+        self.createBannedUseCase = createBannedUseCase
+        self.deleteContentUseCase = deleteContentUseCase
     }
 }
 
@@ -38,15 +47,20 @@ extension HomeViewModel: ViewModelType {
         let didSelectedItem: AnyPublisher<Int, Never>
         let didHeartTappedItem: AnyPublisher<(Int, Bool), Never>
         let didGhostTappedItem: AnyPublisher<(Int, Int), Never>
+        let didDeleteTappedItem: AnyPublisher<Int, Never>
+        let didBannedTappedItem: AnyPublisher<(Int, Int), Never>
+        let didReportTappedItem: AnyPublisher<(String, String), Never>
         let willDisplayLastItem: AnyPublisher<Void, Never>
     }
     
     struct Output {
         let activeUserID: AnyPublisher<Int?, Never>
+        let isAdmin: AnyPublisher<Bool?, Never>
         let contents: AnyPublisher<[Content], Never>
         let selectedContent: AnyPublisher<Content, Never>
         let isLoading: AnyPublisher<Bool, Never>
         let isLoadingMore: AnyPublisher<Bool, Never>
+        let isReportSucceed: AnyPublisher<Bool, Never>
     }
     
     func transform(input: Input, cancelBag: CancelBag) -> Output {
@@ -55,6 +69,8 @@ extension HomeViewModel: ViewModelType {
         let isLoadingMoreSubject = CurrentValueSubject<Bool, Never>(false)
         let isLastViewSubject = CurrentValueSubject<Bool, Never>(false)
         let activeUserIDSubject = CurrentValueSubject<Int?, Never>(nil)
+        let isAdminSubject = CurrentValueSubject<Bool?, Never>(false)
+        let isReportSucceedSubject = CurrentValueSubject<Bool, Never>(false)
         
         let loadTrigger = Publishers.Merge(
             input.viewDidRefresh,
@@ -68,6 +84,18 @@ extension HomeViewModel: ViewModelType {
             }
             .sink { userID in
                 activeUserIDSubject.send(userID)
+            }
+            .store(in: cancelBag)
+        
+        loadTrigger
+            .withUnretained(self)
+            .flatMap { owner, _ -> AnyPublisher<Bool?, Never> in
+                return owner.fetchUserInformationUseCase.fetchActiveUserInfo()
+                    .map { info in info?.isAdmin }
+                    .eraseToAnyPublisher()
+            }
+            .sink { isAdmin in
+                isAdminSubject.send(isAdmin)
             }
             .store(in: cancelBag)
         
@@ -166,7 +194,7 @@ extension HomeViewModel: ViewModelType {
         input.didGhostTappedItem
             .withUnretained(self)
             .flatMap { owner, id -> AnyPublisher<Int, Never> in
-                owner.fetchGhostUseCase.execute(type: .content, targetID: id.0, userID: id.1)
+                return owner.fetchGhostUseCase.execute(type: .content, targetID: id.0, userID: id.1)
                     .map { _ in id.1 }
                     .asDriver(onErrorJustReturn: id.1)
             }
@@ -178,9 +206,8 @@ extension HomeViewModel: ViewModelType {
                 let content = updatedContents[index]
                 let contentInfo = content.content.contentInfo
                 let userContent = content.content
-                
                 let opacity = contentInfo.opacity.reduced()
-
+                
                 let updatedContent = Content(
                     content: UserContent(
                         id: userContent.id,
@@ -198,7 +225,75 @@ extension HomeViewModel: ViewModelType {
                     ),
                     isDeleted: content.isDeleted
                 )
+                
+                updatedContents[index] = updatedContent
+                contentsSubject.send(updatedContents)
+            })
+            .store(in: cancelBag)
+        
+        input.didDeleteTappedItem
+            .withUnretained(self)
+            .flatMap { owner, id -> AnyPublisher<Int, Never> in
+                return owner.deleteContentUseCase.execute(contentID: id)
+                    .map { _ in id }
+                    .asDriver(onErrorJustReturn: id)
+            }
+            .sink(receiveValue: { contentID in
+                var updatedContents = contentsSubject.value
+                
+                guard let index = updatedContents.firstIndex(where: { $0.content.id == contentID }) else { return }
+                
+                updatedContents.remove(at: index)
+                contentsSubject.send(updatedContents)
+            })
+            .store(in: cancelBag)
 
+        input.didReportTappedItem
+            .withUnretained(self)
+            .flatMap { owner, content -> AnyPublisher<Void, Never> in
+                return owner.createReportUseCase.execute(nickname: content.0, text: content.1)
+                    .asDriver(onErrorJustReturn: ())
+            }
+            .sink(receiveValue: { _ in
+                isReportSucceedSubject.send(true)
+            })
+            .store(in: cancelBag)
+        
+        input.didBannedTappedItem
+            .withUnretained(self)
+            .flatMap { owner, content -> AnyPublisher<Int, Never> in
+                return owner.createBannedUseCase.execute(memberID: content.0, triggerType: .content, triggerID: content.1)
+                    .map { _ in content.0 }
+                    .asDriver(onErrorJustReturn: -1)
+            }
+            .sink(receiveValue: { userID in
+                var updatedContents = contentsSubject.value
+                
+                guard let index = updatedContents.firstIndex(where: { $0.content.contentInfo.author.id == userID }) else { return }
+                
+                let content = updatedContents[index]
+                let contentInfo = content.content.contentInfo
+                let userContent = content.content
+                let opacity = contentInfo.opacity.reduced()
+                
+                let updatedContent = Content(
+                    content: UserContent(
+                        id: userContent.id,
+                        contentInfo: ContentInfo(
+                            author: contentInfo.author,
+                            createdDate: contentInfo.createdDate,
+                            title: contentInfo.title,
+                            imageURL: contentInfo.imageURL,
+                            text: contentInfo.text,
+                            status: .blind,
+                            like: contentInfo.like,
+                            opacity: opacity,
+                            commentCount: contentInfo.commentCount
+                        )
+                    ),
+                    isDeleted: content.isDeleted
+                )
+                
                 updatedContents[index] = updatedContent
                 contentsSubject.send(updatedContents)
             })
@@ -211,10 +306,12 @@ extension HomeViewModel: ViewModelType {
         
         return Output(
             activeUserID: activeUserIDSubject.eraseToAnyPublisher(),
+            isAdmin: isAdminSubject.eraseToAnyPublisher(),
             contents: contentsSubject.eraseToAnyPublisher(),
             selectedContent: selectedContent,
             isLoading: isLoadingSubject.eraseToAnyPublisher(),
-            isLoadingMore: isLoadingMoreSubject.eraseToAnyPublisher()
+            isLoadingMore: isLoadingMoreSubject.eraseToAnyPublisher(),
+            isReportSucceed: isReportSucceedSubject.eraseToAnyPublisher()
         )
     }
 }

--- a/Wable-iOS/Presentation/Notification/Activity/View/ActivityNotificationViewController.swift
+++ b/Wable-iOS/Presentation/Notification/Activity/View/ActivityNotificationViewController.swift
@@ -222,13 +222,25 @@ private extension ActivityNotificationViewController {
                         contentID: contentID,
                         contentTitle: "",
                         fetchContentInfoUseCase: FetchContentInfoUseCase(repository: ContentRepositoryImpl()),
-                        createContentLikedUseCase: CreateContentLikedUseCase(repository: ContentLikedRepositoryImpl()),
-                        deleteContentLikedUseCase: DeleteContentLikedUseCase(repository: ContentLikedRepositoryImpl()),
                         fetchContentCommentListUseCase: FetchContentCommentListUseCase(repository: CommentRepositoryImpl()),
                         createCommentUseCase: CreateCommentUseCase(repository: CommentRepositoryImpl()),
                         deleteCommentUseCase: DeleteCommentUseCase(repository: CommentRepositoryImpl()),
+                        createContentLikedUseCase: CreateContentLikedUseCase(repository: ContentLikedRepositoryImpl()),
+                        deleteContentLikedUseCase: DeleteContentLikedUseCase(repository: ContentLikedRepositoryImpl()),
                         createCommentLikedUseCase: CreateCommentLikedUseCase(repository: CommentLikedRepositoryImpl()),
-                        deleteCommentLikedUseCase: DeleteCommentLikedUseCase(repository: CommentLikedRepositoryImpl())
+                        deleteCommentLikedUseCase: DeleteCommentLikedUseCase(repository: CommentLikedRepositoryImpl()),
+                        fetchUserInformationUseCase: FetchUserInformationUseCase(
+                            repository: UserSessionRepositoryImpl(
+                                userDefaults: UserDefaultsStorage(
+                                    jsonEncoder: JSONEncoder(),
+                                    jsonDecoder: JSONDecoder()
+                                )
+                            )
+                        ),
+                        fetchGhostUseCase: FetchGhostUseCase(repository: GhostRepositoryImpl()),
+                        createReportUseCase: CreateReportUseCase(repository: ReportRepositoryImpl()),
+                        createBannedUseCase: CreateBannedUseCase(repository: ReportRepositoryImpl()),
+                        deleteContentUseCase: DeleteContentUseCase(repository: ContentRepositoryImpl())
                     ),
                     cancelBag: CancelBag()
                 )

--- a/Wable-iOS/Presentation/Notification/Information/View/InformationNotificationViewController.swift
+++ b/Wable-iOS/Presentation/Notification/Information/View/InformationNotificationViewController.swift
@@ -200,13 +200,25 @@ private extension InformationNotificationViewController {
                         contentID: item.id,
                         contentTitle: "",
                         fetchContentInfoUseCase: FetchContentInfoUseCase(repository: ContentRepositoryImpl()),
-                        createContentLikedUseCase: CreateContentLikedUseCase(repository: ContentLikedRepositoryImpl()),
-                        deleteContentLikedUseCase: DeleteContentLikedUseCase(repository: ContentLikedRepositoryImpl()),
                         fetchContentCommentListUseCase: FetchContentCommentListUseCase(repository: CommentRepositoryImpl()),
                         createCommentUseCase: CreateCommentUseCase(repository: CommentRepositoryImpl()),
                         deleteCommentUseCase: DeleteCommentUseCase(repository: CommentRepositoryImpl()),
+                        createContentLikedUseCase: CreateContentLikedUseCase(repository: ContentLikedRepositoryImpl()),
+                        deleteContentLikedUseCase: DeleteContentLikedUseCase(repository: ContentLikedRepositoryImpl()),
                         createCommentLikedUseCase: CreateCommentLikedUseCase(repository: CommentLikedRepositoryImpl()),
-                        deleteCommentLikedUseCase: DeleteCommentLikedUseCase(repository: CommentLikedRepositoryImpl())
+                        deleteCommentLikedUseCase: DeleteCommentLikedUseCase(repository: CommentLikedRepositoryImpl()),
+                        fetchUserInformationUseCase: FetchUserInformationUseCase(
+                            repository: UserSessionRepositoryImpl(
+                                userDefaults: UserDefaultsStorage(
+                                    jsonEncoder: JSONEncoder(),
+                                    jsonDecoder: JSONDecoder()
+                                )
+                            )
+                        ),
+                        fetchGhostUseCase: FetchGhostUseCase(repository: GhostRepositoryImpl()),
+                        createReportUseCase: CreateReportUseCase(repository: ReportRepositoryImpl()),
+                        createBannedUseCase: CreateBannedUseCase(repository: ReportRepositoryImpl()),
+                        deleteContentUseCase: DeleteContentUseCase(repository: ContentRepositoryImpl())
                     ),
                     cancelBag: CancelBag()
                 )

--- a/Wable-iOS/Presentation/TabBar/TabBarController.swift
+++ b/Wable-iOS/Presentation/TabBar/TabBarController.swift
@@ -21,7 +21,15 @@ final class TabBarController: UITabBarController {
         viewModel: HomeViewModel(
             fetchContentListUseCase: FetchContentListUseCase(repository: ContentRepositoryImpl()),
             createContentLikedUseCase: CreateContentLikedUseCase(repository: ContentLikedRepositoryImpl()),
-            deleteContentLikedUseCase: DeleteContentLikedUseCase(repository: ContentLikedRepositoryImpl())
+            deleteContentLikedUseCase: DeleteContentLikedUseCase(repository: ContentLikedRepositoryImpl()),
+            fetchUserInformationUseCase: FetchUserInformationUseCase(
+                repository: UserSessionRepositoryImpl(
+                    userDefaults: UserDefaultsStorage(
+                        jsonEncoder: JSONEncoder(),
+                        jsonDecoder: JSONDecoder()
+                    )
+                )
+            )
         ),
         cancelBag: CancelBag()
     ).then {

--- a/Wable-iOS/Presentation/TabBar/TabBarController.swift
+++ b/Wable-iOS/Presentation/TabBar/TabBarController.swift
@@ -29,7 +29,8 @@ final class TabBarController: UITabBarController {
                         jsonDecoder: JSONDecoder()
                     )
                 )
-            )
+            ),
+            fetchGhostUseCase: FetchGhostUseCase(repository: GhostRepositoryImpl())
         ),
         cancelBag: CancelBag()
     ).then {

--- a/Wable-iOS/Presentation/TabBar/TabBarController.swift
+++ b/Wable-iOS/Presentation/TabBar/TabBarController.swift
@@ -30,7 +30,10 @@ final class TabBarController: UITabBarController {
                     )
                 )
             ),
-            fetchGhostUseCase: FetchGhostUseCase(repository: GhostRepositoryImpl())
+            fetchGhostUseCase: FetchGhostUseCase(repository: GhostRepositoryImpl()),
+            createReportUseCase: CreateReportUseCase(repository: ReportRepositoryImpl()),
+            createBannedUseCase: CreateBannedUseCase(repository: ReportRepositoryImpl()),
+            deleteContentUseCase: DeleteContentUseCase(repository: ContentRepositoryImpl())
         ),
         cancelBag: CancelBag()
     ).then {

--- a/Wable-iOS/Presentation/WableComponent/Cell/ContentCollectionViewCell.swift
+++ b/Wable-iOS/Presentation/WableComponent/Cell/ContentCollectionViewCell.swift
@@ -287,7 +287,7 @@ extension ContentCollectionViewCell {
         commentButton.isUserInteractionEnabled = cellType == .detail
         
         ghostButton.configureButton(type: .large, status: .normal)
-        ghostButton.isHidden = postType == .mine
+        ghostButton.isHidden = postType == .mine || info.status == .ghost
         
         switch info.status {
         case .normal:

--- a/Wable-iOS/Presentation/WableComponent/Cell/ContentCollectionViewCell.swift
+++ b/Wable-iOS/Presentation/WableComponent/Cell/ContentCollectionViewCell.swift
@@ -32,8 +32,12 @@ final class ContentCollectionViewCell: UICollectionViewCell {
     // MARK: - Property
     // TODO: 셀 타입 따라 이미지 크기 설정하는 분기 처리 필요
     
-    private var cellType: CellType = .list
     var likeButtonTapHandler: (() -> Void)?
+    var profileImageViewTapHandler: (() -> Void)?
+    var settingButtonTapHandler: (() -> Void)?
+    var ghostButtonTapHandler: (() -> Void)?
+    
+    private var cellType: CellType = .list
     
     // MARK: - UIComponent
     
@@ -166,7 +170,6 @@ private extension ContentCollectionViewCell {
     func setupAction() {
         ghostButton.addTarget(self, action: #selector(ghostButtonDidTap), for: .touchUpInside)
         infoView.settingButton.addTarget(self, action: #selector(settingButtonDidTap), for: .touchUpInside)
-        commentButton.addTarget(self, action: #selector(commentButtonDidTap), for: .touchUpInside)
         likeButton.addTarget(self, action: #selector(likeButtonDidTap), for: .touchUpInside)
         contentImageView.addGestureRecognizer(
             UITapGestureRecognizer(
@@ -196,27 +199,15 @@ private extension ContentCollectionViewCell {
     }
     
     @objc func profileImageViewDidTap() {
-        // TODO: 프로필 이동 로직 구현 필요
-        
-        WableLogger.log("profileImageViewDidTap", for: .debug)
+        profileImageViewTapHandler?()
     }
     
     @objc func settingButtonDidTap() {
-        // TODO: 바텀시트 올라오는 로직 구현 필요
-        
-        WableLogger.log("settingButtonDidTap", for: .debug)
+        settingButtonTapHandler?()
     }
     
     @objc func ghostButtonDidTap() {
-        // TODO: 내리기 로직 구현 필요
-        
-        WableLogger.log("ghostButtonDidTap", for: .debug)
-    }
-    
-    @objc func commentButtonDidTap() {
-        // TODO: 상세 화면으로 이동 로직 구현 필요
-        
-        WableLogger.log("commentButtonDidTap", for: .debug)
+        ghostButtonTapHandler?()
     }
     
     @objc func likeButtonDidTap() {
@@ -258,10 +249,16 @@ extension ContentCollectionViewCell {
         info: ContentInfo,
         postType: AuthorType,
         cellType: CellType = .list,
-        likeButtonTapHandler: (() -> Void)?
+        likeButtonTapHandler: (() -> Void)?,
+        settingButtonTapHandler: (() -> Void)?,
+        profileImageViewTapHandler: (() -> Void)?,
+        ghostButtonTapHandler: (() -> Void)?
     ) {
         self.cellType = cellType
         self.likeButtonTapHandler = likeButtonTapHandler
+        self.ghostButtonTapHandler = ghostButtonTapHandler
+        self.profileImageViewTapHandler = profileImageViewTapHandler
+        self.settingButtonTapHandler = settingButtonTapHandler
         
         guard let createdDate = info.createdDate else { return }
         

--- a/Wable-iOS/Presentation/WableComponent/Cell/ContentCollectionViewCell.swift
+++ b/Wable-iOS/Presentation/WableComponent/Cell/ContentCollectionViewCell.swift
@@ -281,18 +281,13 @@ extension ContentCollectionViewCell {
         contentTextView.text = info.text
         contentTextView.isUserInteractionEnabled = cellType == .detail
         
-        ghostButton.configureButton(type: .large, status: .normal)
         likeButton.configureButton(isLiked: info.like.status, likeCount: info.like.count, postType: .content)
         
         commentButton.configureButton(commentCount: info.commentCount)
         commentButton.isUserInteractionEnabled = cellType == .detail
         
-        switch postType {
-        case .mine:
-            ghostButton.isHidden = true
-        case .others:
-            break
-        }
+        ghostButton.configureButton(type: .large, status: .normal)
+        ghostButton.isHidden = postType == .mine
         
         switch info.status {
         case .normal:

--- a/Wable-iOS/Presentation/WableComponent/Cell/ContentCollectionViewCell.swift
+++ b/Wable-iOS/Presentation/WableComponent/Cell/ContentCollectionViewCell.swift
@@ -17,7 +17,7 @@ import UIKit
 ///
 /// // cellForItemAt에서:
 /// let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ContentCollectionViewCell.reuseIdentifier, for: indexPath) as! ContentCollectionViewCell
-/// cell.configureCell(info: contentInfo, postType: .others)
+/// cell.configureCell(info: contentInfo, authorType: .others)
 /// return cell
 /// ```
 final class ContentCollectionViewCell: UICollectionViewCell {
@@ -242,12 +242,12 @@ extension ContentCollectionViewCell {
     /// 게시물 셀 구성 메서드
     /// - Parameters:
     ///   - info: 게시물 정보
-    ///   - postType: 게시물 타입 (.mine 또는 .others)
+    ///   - authorType: 게시물 타입 (.mine 또는 .others)
     ///   - cellType: 셀 타입 (홈 화면 셀 또는 상세 화면 셀)
     ///   - likeButtonTapHandler: 좋아요 버튼을 클릭했을 때 실행될 로직
     func configureCell(
         info: ContentInfo,
-        postType: AuthorType,
+        authorType: AuthorType,
         cellType: CellType = .list,
         likeButtonTapHandler: (() -> Void)?,
         settingButtonTapHandler: (() -> Void)?,
@@ -287,7 +287,7 @@ extension ContentCollectionViewCell {
         commentButton.isUserInteractionEnabled = cellType == .detail
         
         ghostButton.configureButton(type: .large, status: .normal)
-        ghostButton.isHidden = postType == .mine || info.status == .ghost
+        ghostButton.isHidden = authorType == .mine || info.status == .ghost
         
         switch info.status {
         case .normal:

--- a/Wable-iOS/Presentation/WableComponent/ViewController/WableSheetViewController.swift
+++ b/Wable-iOS/Presentation/WableComponent/ViewController/WableSheetViewController.swift
@@ -62,7 +62,7 @@ final class WableSheetViewController: UIViewController {
     }
     
     private lazy var titleLabel = UILabel().then {
-        $0.attributedText = self.sheetTitle.pretendardString(with: .head1)
+        $0.attributedText = self.sheetTitle.pretendardString(with: .head2)
         $0.numberOfLines = 0
         $0.textAlignment = .center
     }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 세부 화면의 게시물 작성자 구분 기능을 구현했습니다.
- 세부 화면의 내리기 기능을 구현했습니다.
- 세부 화면의 신고하기, 삭제하기, 밴하기 기능을 구현했습니다.

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 홈 화면과 코드가 거의 비슷해서 따로 코드 설명은 작성하지 않았습니다. 궁금하신 부분 있으시면 언제든지 불러주세요!
- 홈 화면 브랜치에서 작업한 내용이 세부 화면에도 거의 동일하게 쓰여서 홈 화면 브랜치에서 새 브랜치를 생성했는데 이렇게 하면 홈 화면에서 구현한 내용도 모두 files changed로 들어가네요 ㅎㅎ... 
- 홈 화면 리뷰 후 머지하신 후에 해당 PR 리뷰해주셔도 좋을 듯 합니다!

## 🔗 연결된 이슈
- Resolved: #180


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced ghosting, reporting, banning, and content deletion actions for posts and comments, including confirmation dialogs and admin-specific options.
  - Added support for displaying toast notifications upon successful report submissions.
  - Enhanced content and comment cells with new interactive buttons (ghost, report, ban, reply, profile image).
  - Improved state management for active user identity and admin status.

- **Improvements**
  - Refined UI feedback for moderation actions, such as hiding deleted comments and updating cell appearance for ghosted or banned content.
  - Updated font style for sheet view titles for a more consistent look.

- **Bug Fixes**
  - Ensured deleted comments and their replies are excluded from display.

- **Refactor**
  - Streamlined cell configuration and event handling for better maintainability and scalability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->