### PR TITLE
[Fix] 프로필 화면 런타임 에러 해결

### DIFF
--- a/Wable-iOS/Presentation/Profile/My/View/MyProfileViewController.swift
+++ b/Wable-iOS/Presentation/Profile/My/View/MyProfileViewController.swift
@@ -97,6 +97,10 @@ extension MyProfileViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let section = Section(rawValue: indexPath.section), section == .post else { return }
         
+        if collectionView.cellForItem(at: indexPath) is MyProfileEmptyCell {
+            return
+        }
+        
         let contentID = viewModel.didSelect(index: indexPath.item)
         
         let viewController = HomeDetailViewController(

--- a/Wable-iOS/Presentation/Profile/Other/View/OtherProfileViewController.swift
+++ b/Wable-iOS/Presentation/Profile/Other/View/OtherProfileViewController.swift
@@ -95,6 +95,10 @@ extension OtherProfileViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let section = Section(rawValue: indexPath.section), section == .post else { return }
         
+        if collectionView.cellForItem(at: indexPath) is OtherProfileEmptyCell {
+            return
+        }
+        
         let contentID = viewModel.didSelect(index: indexPath.item)
         
         let viewController = HomeDetailViewController(


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 프로필 화면에서 엠티뷰 처리를 위한 셀을 터치 시, 런타임 에러가 발생하는 문제를 해결하였습니다.

## 🔗 연결된 이슈
- Resolved: #205 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tapping on empty profile cells in the post section no longer triggers any actions or navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->