### PR TITLE
[Fix] 2차 QA 반영

### DIFF
--- a/Wable-iOS/Core/Literals/String/StringLiterals+ProfileSetting.swift
+++ b/Wable-iOS/Core/Literals/String/StringLiterals+ProfileSetting.swift
@@ -15,7 +15,7 @@ extension StringLiterals {
     enum ProfileSetting {
         static let registerTitle = "와블에서 활동할\n프로필을 등록해 주세요"
         static let registerDescription = "프로필 사진은 나중에도 등록 가능해요"
-        static let editTitle = "와블에서 멋진 모습으로 활동해 보세요!"
+        static let editTitle = "와블에서 멋진 모습으로\n활동해 보세요!"
         static let checkDefaultMessage = "10자리 이내, 문자/숫자로 입력 가능해요"
         static let checkInvaildError = "닉네임에 사용할 수 없는 문자가 포함되어 있어요."
         static let checkDuplicateError = "이미 사용 중인 닉네임입니다."

--- a/Wable-iOS/Presentation/Home/View/HomeDetailViewController.swift
+++ b/Wable-iOS/Presentation/Home/View/HomeDetailViewController.swift
@@ -126,6 +126,7 @@ final class HomeDetailViewController: NavigationViewController {
         setupConstraint()
         setupDataSource()
         setupAction()
+        setupTapGesture()
         setupDelegate()
         setupBinding()
     }
@@ -188,6 +189,12 @@ private extension HomeDetailViewController {
             $0.centerX.equalToSuperview()
             $0.bottom.equalTo(writeCommentView.snp.top)
         }
+    }
+    
+    private func setupTapGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
     }
     
     func setupDataSource() {
@@ -691,6 +698,15 @@ private extension HomeDetailViewController {
         placeholderLabel.isHidden = !commentTextView.text.isEmpty
     }
 }
+
+// MARK: - @objc method
+
+extension HomeDetailViewController {
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
+    }
+}
+
 
 // MARK: - UICollectionViewDelegate
 

--- a/Wable-iOS/Presentation/Home/View/HomeDetailViewController.swift
+++ b/Wable-iOS/Presentation/Home/View/HomeDetailViewController.swift
@@ -284,7 +284,26 @@ private extension HomeDetailViewController {
                     self.present(viewController, animated: true)
                 },
                 profileImageViewTapHandler: {
-                    // TODO: 프로필 구현되는 대로 추가적인 설정 필요
+                    if self.activeUserID == item.content.contentInfo.author.id,
+                       let tabBarController = self.tabBarController {
+                        tabBarController.selectedIndex = 4
+                    } else {
+                        let viewController = OtherProfileViewController(
+                            viewModel: .init(
+                                userID: item.content.contentInfo.author.id,
+                                fetchUserProfileUseCase: FetchUserProfileUseCaseImpl(),
+                                checkUserRoleUseCase: CheckUserRoleUseCaseImpl(
+                                    repository: UserSessionRepositoryImpl(
+                                        userDefaults: .init(
+                                            jsonEncoder: .init(),
+                                            jsonDecoder: .init()
+                                        )
+                                    )
+                                )
+                            ))
+                        
+                        self.navigationController?.pushViewController(viewController, animated: true)
+                    }
                 },
                 ghostButtonTapHandler: {
                     let viewController = WableSheetViewController(title: StringLiterals.Ghost.sheetTitle)

--- a/Wable-iOS/Presentation/Home/View/HomeDetailViewController.swift
+++ b/Wable-iOS/Presentation/Home/View/HomeDetailViewController.swift
@@ -78,10 +78,12 @@ final class HomeDetailViewController: NavigationViewController {
         $0.layer.cornerRadius = 16
         $0.isScrollEnabled = false
         $0.backgroundColor = .gray100
-        $0.setPretendard(with: .body4)
+        $0.font = .pretendard(.body4)
         $0.textContainer.lineFragmentPadding = .zero
-        $0.textContainerInset = .init(top: 10, left: 10, bottom: 10, right: 10)
         $0.text = ""
+        $0.textContainerInset.top = 12
+        $0.textContainerInset.left = 8
+        $0.textContainerInset.bottom = 12
     }
     
     private lazy var placeholderLabel: UILabel = UILabel().then {
@@ -167,7 +169,8 @@ private extension HomeDetailViewController {
             $0.verticalEdges.equalToSuperview().inset(10)
             $0.leading.equalToSuperview().offset(16)
             $0.trailing.equalTo(createCommentButton.snp.leading).offset(-7)
-            $0.height.lessThanOrEqualTo(80.adjustedHeight)
+            $0.height.greaterThanOrEqualTo(42.adjustedHeight)
+            $0.height.lessThanOrEqualTo(76.adjustedHeight)
         }
         
         placeholderLabel.snp.makeConstraints {

--- a/Wable-iOS/Presentation/Home/View/WritePostViewController.swift
+++ b/Wable-iOS/Presentation/Home/View/WritePostViewController.swift
@@ -25,21 +25,21 @@ final class WritePostViewController: NavigationViewController {
     }
     
     private let stackView: UIStackView = .init(axis: .vertical).then {
-        $0.spacing = 12
+        $0.spacing = 4
     }
     
     private lazy var titleTextView: UITextView = .init().then {
         $0.isScrollEnabled = false
-        $0.textContainerInset = .zero
-        $0.setPretendard(with: .head1, text: StringLiterals.Write.sheetTitle)
+        $0.font = .pretendard(.head1)
+        $0.text = StringLiterals.Write.sheetTitle
         $0.textColor = .gray500
         $0.backgroundColor = .clear
     }
     
     private lazy var contentTextView: UITextView = .init().then {
         $0.isScrollEnabled = false
-        $0.textContainerInset = .zero
-        $0.setPretendard(with: .body2, text: StringLiterals.Write.sheetMessage)
+        $0.font = .pretendard(.body2)
+        $0.text = StringLiterals.Write.sheetMessage
         $0.textColor = .gray500
         $0.backgroundColor = .clear
     }

--- a/Wable-iOS/Presentation/Home/View/WritePostViewController.swift
+++ b/Wable-iOS/Presentation/Home/View/WritePostViewController.swift
@@ -256,14 +256,15 @@ private extension WritePostViewController {
 
 private extension WritePostViewController {
     private func updateCharacterCount() {
-        let titleText = titleTextView.textColor == .gray700 ? "" : titleTextView.text
-        let contentText = contentTextView.textColor == .gray500 ? "" : contentTextView.text
+        let titleText = titleTextView.textColor == .wableBlack ? titleTextView.text : ""
+        let contentText = contentTextView.textColor == .wableBlack ? contentTextView.text : ""
         
         let titleCount = titleText?.count ?? 0
         let contentCount = contentText?.count ?? 0
         let totalCount = titleCount + contentCount
         
         countLabel.text = "\(totalCount)/500"
+        countLabel.textColor = totalCount >= 500 ? .error : .gray600
         
         if titleCount > 250 {
             titleTextView.text = String(titleTextView.text.prefix(250))
@@ -351,14 +352,16 @@ extension WritePostViewController: UITextViewDelegate {
     }
     
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        let isPlaceholder = textView == titleTextView || textView == contentTextView 
-         
-        if isPlaceholder {
+        let isCurrentPlaceholder = (textView == titleTextView && textView.text == StringLiterals.Write.sheetTitle) ||
+                                 (textView == contentTextView && textView.text == StringLiterals.Write.sheetMessage)
+        
+        if isCurrentPlaceholder {
             return true
         }
         
-        let titleCount = titleTextView.textColor == .gray500 ? 0 : titleTextView.text.count
-        let contentCount = contentTextView.textColor == .gray500 ? 0 : contentTextView.text.count
+        let titleCount = titleTextView.textColor == .wableBlack ? titleTextView.text.count : 0
+        let contentCount = contentTextView.textColor == .wableBlack ? contentTextView.text.count : 0
+        
         let currentCount = textView == titleTextView ? titleCount : contentCount
         let otherCount = textView == titleTextView ? contentCount : titleCount
         
@@ -374,6 +377,6 @@ extension WritePostViewController: UITextViewDelegate {
             return false
         }
         
-        return (newTextCount - currentCount) + otherCount + currentCount < 500
+        return (newTextCount - currentCount) + otherCount + currentCount <= 500
     }
 }

--- a/Wable-iOS/Presentation/Profile/Edit/ProfileEditViewController.swift
+++ b/Wable-iOS/Presentation/Profile/Edit/ProfileEditViewController.swift
@@ -127,6 +127,8 @@ private extension ProfileEditViewController {
     }
     
     @objc func duplicationCheckButtonDidTap() {
+        rootView.nickNameTextField.endEditing(true)
+        
         guard let text = rootView.nickNameTextField.text else { return }
 
         nicknameUseCase.execute(nickname: text)

--- a/Wable-iOS/Presentation/Profile/Edit/ProfileEditViewController.swift
+++ b/Wable-iOS/Presentation/Profile/Edit/ProfileEditViewController.swift
@@ -14,7 +14,6 @@ final class ProfileEditViewController: NavigationViewController {
     // MARK: Property
     // TODO: 유즈케이스 리팩 후에 뷰모델 만들어 넘기기
     
-    private var defaultImage: String? = nil
     private let profileUseCase = UserProfileUseCase(repository: ProfileRepositoryImpl())
     private let nicknameUseCase = FetchNicknameDuplicationUseCase(repository: AccountRepositoryImpl())
     private let userSessionUseCase = FetchUserInformationUseCase(
@@ -28,6 +27,8 @@ final class ProfileEditViewController: NavigationViewController {
     private let cancelBag = CancelBag()
     
     private var sessionProfile: UserProfile? = nil
+    private var defaultImage: String? = nil
+    private var hasUserSelectedImage = false
     
     // MARK: - UIComponent
     
@@ -58,6 +59,8 @@ final class ProfileEditViewController: NavigationViewController {
         
         self.updateSessionInfo()
         rootView.nickNameTextField.text = nil
+        hasUserSelectedImage = false
+        defaultImage = nil
     }
 }
 
@@ -107,6 +110,8 @@ private extension ProfileEditViewController {
     @objc func switchButtonDidTap() {
         rootView.configureDefaultImage()
         defaultImage = rootView.defaultImageList[0].uppercased
+        hasUserSelectedImage = false
+        updateNextButtonState()
     }
     
     @objc func addButtonDidTap() {
@@ -148,33 +153,38 @@ private extension ProfileEditViewController {
     @objc func nextButtonDidTap() {
         guard let profile = sessionProfile else { return }
         
-        guard let text = rootView.nickNameTextField.text,
-              text != "" else {
-            return
-        }
+        let nicknameText = rootView.nickNameTextField.text ?? ""
+        let hasNicknameChanged = !nicknameText.isEmpty && nicknameText != profile.user.nickname
+        let hasImageChanged = defaultImage != nil || hasUserSelectedImage
         
-        profileUseCase.execute(
-            profile: UserProfile(
-                user: User(
-                    id: profile.user.id,
-                    nickname: text,
-                    profileURL: profile.user.profileURL,
-                    fanTeam: profile.user.fanTeam
+        if hasNicknameChanged || hasImageChanged {
+            let finalNickname = hasNicknameChanged ? nicknameText : profile.user.nickname
+            
+            profileUseCase.execute(
+                profile: UserProfile(
+                    user: User(
+                        id: profile.user.id,
+                        nickname: finalNickname,
+                        profileURL: profile.user.profileURL,
+                        fanTeam: profile.user.fanTeam
+                    ),
+                    introduction: profile.introduction,
+                    ghostCount: profile.ghostCount,
+                    lckYears: profile.lckYears,
+                    userLevel: profile.userLevel
                 ),
-                introduction: profile.introduction,
-                ghostCount: profile.ghostCount,
-                lckYears: profile.lckYears,
-                userLevel: profile.userLevel
-            ),
-            image: defaultImage == nil ? rootView.profileImageView.image : nil,
-            defaultProfileType: defaultImage
-        )
-        .withUnretained(self)
-        .sink { _ in
-        } receiveValue: { owner, _ in
-            owner.navigationController?.popViewController(animated: true)
+                image: defaultImage == nil ? rootView.profileImageView.image : nil,
+                defaultProfileType: defaultImage
+            )
+            .withUnretained(self)
+            .sink { _ in
+            } receiveValue: { owner, _ in
+                owner.navigationController?.popViewController(animated: true)
+            }
+            .store(in: cancelBag)
+        } else {
+            navigationController?.popViewController(animated: true)
         }
-        .store(in: cancelBag)
     }
     
     // MARK: - Function Method
@@ -204,6 +214,19 @@ private extension ProfileEditViewController {
         })
         
         present(alert, animated: true, completion: nil)
+    }
+    
+    func updateNextButtonState() {
+        guard let profile = sessionProfile else { return }
+        
+        let nicknameText = rootView.nickNameTextField.text ?? ""
+        let hasNicknameChanged = !nicknameText.isEmpty && nicknameText != profile.user.nickname
+        let hasImageChanged = defaultImage != nil || hasUserSelectedImage
+        
+        let shouldEnable = hasNicknameChanged || hasImageChanged
+        
+        rootView.nextButton.isUserInteractionEnabled = shouldEnable
+        rootView.nextButton.updateStyle(shouldEnable ? .primary : .gray)
     }
 }
 
@@ -240,6 +263,8 @@ extension ProfileEditViewController: PHPickerViewControllerDelegate {
             DispatchQueue.main.async {
                 self.rootView.profileImageView.image = image
                 self.defaultImage = nil
+                self.hasUserSelectedImage = true
+                self.updateNextButtonState()
             }
         }
         


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 기존 상세 페이지 댓글 작성 영역, 글 작성 페이지 제목, 본문 영역에 구현되어 있던 자간, 행간을 삭제했어요.
- 2차 QA에서 나온 사항들을 반영했어요.
  - 프로필 수정 시 사진만 수정해도 프로필 수정이 가능하도록 조건을 추가했어요.
  - 글 작성 시 글자 제한을 499자에서 500자로 수정했어요.
  - 댓글 작성 시 뷰 영역 클릭 시 키보드가 내려가도록 수정했어요.
  - 프로필 수정 뷰에서 중복 확인 버튼 클릭 시 키보드가 내려가도록 구현했어요.
- 상세 페이지에서 게시글 프로필 클릭 시 페이지가 전환되는 로직을 구현했어요.
  - 이 부분은 제가 구현을 깜빡해서 ㅎㅎ... 이번 이슈에서 같이 작업했습니다!

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 자간 행간 삭제는 기획-디자인과 모두 이야기된 부분이라 걱정 안하셔도 됩니다! 이후 타자 영역 문제가 해결되면 다시 넣어둘 계획입니다.

## 🔗 연결된 이슈
- Resolved: #208 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved formatting of profile setting titles for better readability.
  - Adjusted comment input and post writing views for more consistent spacing and font usage.

- **New Features**
  - Added the ability to dismiss the keyboard by tapping outside the comment input area.
  - Enhanced profile editing to better detect and respond to changes in nickname or profile image.

- **Bug Fixes**
  - Refined placeholder and character count handling in post writing to ensure accurate limits and feedback.

- **Refactor**
  - Centralized logic for enabling the profile edit button, improving UI responsiveness when editing profile details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->