### PR TITLE
[Fix] 상세 화면 댓글 작성 뷰 로직 수정

### DIFF
--- a/Wable-iOS/Presentation/Home/View/HomeDetailViewController.swift
+++ b/Wable-iOS/Presentation/Home/View/HomeDetailViewController.swift
@@ -863,7 +863,7 @@ extension HomeDetailViewController {
 
 extension HomeDetailViewController: UITextViewDelegate {
     func textViewDidEndEditing(_ textView: UITextView) {
-        placeholderLabel.isHidden = !textView.text.isEmpty
+        updatePlaceholderVisibility(textView)
     }
     
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
@@ -875,14 +875,13 @@ extension HomeDetailViewController: UITextViewDelegate {
         
         let newText = oldText.replacingCharacters(in: stringRange, with: text)
         
-        placeholderLabel.isHidden = !newText.isEmpty
-        
         return newText.count <= 500
     }
     
     func textViewDidChange(_ textView: UITextView) {
-        placeholderLabel.isHidden = !textView.text.isEmpty
-        createCommentButton.isEnabled = !textView.text.isEmpty
+        updatePlaceholderVisibility(textView)
+        
+        createCommentButton.isEnabled = !textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         
         let size = CGSize(width: textView.frame.width, height: .infinity)
         let estimatedSize = textView.sizeThatFits(size)
@@ -894,6 +893,13 @@ extension HomeDetailViewController: UITextViewDelegate {
         textView.setNeedsUpdateConstraints()
         
         textView.superview?.layoutIfNeeded()
+    }
+    
+    private func updatePlaceholderVisibility(_ textView: UITextView) {
+        let hasText = !textView.text.isEmpty
+        let hasMarkedText = textView.markedTextRange != nil
+        
+        placeholderLabel.isHidden = hasText || hasMarkedText
     }
 }
 

--- a/Wable-iOS/Presentation/WableComponent/Cell/CommentCollectionViewCell.swift
+++ b/Wable-iOS/Presentation/WableComponent/Cell/CommentCollectionViewCell.swift
@@ -285,8 +285,8 @@ extension CommentCollectionViewCell {
                 $0.top.equalTo(infoView.snp.bottom).offset(12)
                 $0.leading.equalTo(likeButton)
                 $0.trailing.equalToSuperview().inset(16)
-                $0.bottom.equalTo(ghostButton.snp.top).offset(-12)
-                $0.adjustedHeightEqualTo(50)
+                $0.bottom.lessThanOrEqualTo(ghostButton.snp.top).offset(-12)
+                $0.adjustedHeightEqualTo(50).priority(.high)
             }
             
             DispatchQueue.main.async {

--- a/Wable-iOS/Presentation/WableComponent/Cell/CommentCollectionViewCell.swift
+++ b/Wable-iOS/Presentation/WableComponent/Cell/CommentCollectionViewCell.swift
@@ -271,7 +271,6 @@ extension CommentCollectionViewCell {
     }
     
     func configurePostStatus(info: CommentInfo) {
-        WableLogger.log("\(info.status)", for: .error)
         switch info.status {
         case .normal:
             ghostCell(opacity: info.opacity.alpha)


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 상세 화면 댓글 작성 텍스트뷰 로직을 수정했어요.
- 상세 화면 게시 버튼 활성화 조건을 수정했어요.

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 조합 중인 텍스트 확인 로직 추가
```swift
let hasMarkedText = textView.markedTextRange != nil
placeholderLabel.isHidden = hasText || hasMarkedText
```
- `markedTextRange`를 사용하면 조합 중인 텍스트를 확인할 수 있다고 합니다.
- 해당 로직을 추가해 텍스트를 조합 중일 때에도 비어있다고 인식하지 않도록 코드를 수정했습니다.

## 🔗 연결된 이슈
- Resolved: #224 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the logic for enabling the comment button, ensuring it is not enabled when the input contains only whitespace or newlines.
- **Refactor**
	- Streamlined and unified the logic for showing and hiding the placeholder in the comment input field for more consistent behavior.
- **UI Improvements**
	- Enhanced layout flexibility for comment status indicators to improve visual spacing and presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->