### PR TITLE
[Feat] 사진 저장 시 와블 토스트를 이용한 결과 보여주기

### DIFF
--- a/Wable-iOS.xcodeproj/project.pbxproj
+++ b/Wable-iOS.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		DE0D0CAA2DD2041100FB64DC /* LikeViewitUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0D0CA92DD2041100FB64DC /* LikeViewitUseCase.swift */; };
 		DE0D0CAC2DD204D000FB64DC /* ReportViewitUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0D0CAB2DD204D000FB64DC /* ReportViewitUseCase.swift */; };
 		DE0DC22B2E0AEB9600FF061E /* GhostInfoTooltipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0DC22A2E0AEB9600FF061E /* GhostInfoTooltipView.swift */; };
+		DE0DC22F2E0B008F00FF061E /* StringLiterals+PhotoDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0DC22E2E0B008F00FF061E /* StringLiterals+PhotoDetail.swift */; };
 		DE202FF62DE784FB00B04CAA /* AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE202FF52DE784FB00B04CAA /* AppVersion.swift */; };
 		DE202FF82DE7856E00B04CAA /* UpdateRequirement.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE202FF72DE7856E00B04CAA /* UpdateRequirement.swift */; };
 		DE202FFA2DE785E800B04CAA /* AppVersionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE202FF92DE785E800B04CAA /* AppVersionRepository.swift */; };
@@ -627,6 +628,7 @@
 		DE0D0CA92DD2041100FB64DC /* LikeViewitUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikeViewitUseCase.swift; sourceTree = "<group>"; };
 		DE0D0CAB2DD204D000FB64DC /* ReportViewitUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportViewitUseCase.swift; sourceTree = "<group>"; };
 		DE0DC22A2E0AEB9600FF061E /* GhostInfoTooltipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostInfoTooltipView.swift; sourceTree = "<group>"; };
+		DE0DC22E2E0B008F00FF061E /* StringLiterals+PhotoDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StringLiterals+PhotoDetail.swift"; sourceTree = "<group>"; };
 		DE202FF52DE784FB00B04CAA /* AppVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersion.swift; sourceTree = "<group>"; };
 		DE202FF72DE7856E00B04CAA /* UpdateRequirement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateRequirement.swift; sourceTree = "<group>"; };
 		DE202FF92DE785E800B04CAA /* AppVersionRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionRepository.swift; sourceTree = "<group>"; };
@@ -1595,6 +1597,7 @@
 				DDF97CB12DE4EAC7009FC612 /* StringLiterals+URL.swift */,
 				DDF97CB22DE4EAC7009FC612 /* StringLiterals+Viewit.swift */,
 				DDF97CB32DE4EAC7009FC612 /* StringLiterals+Write.swift */,
+				DE0DC22E2E0B008F00FF061E /* StringLiterals+PhotoDetail.swift */,
 			);
 			path = String;
 			sourceTree = "<group>";
@@ -2710,6 +2713,7 @@
 				DE4AE8532DE8BA18003E20AB /* UIAlertShowable.swift in Sources */,
 				DD2968132D6DACF700143851 /* TriggerType.swift in Sources */,
 				DD9980DF2D834F4E00EBBFBC /* CommentCollectionViewCell.swift in Sources */,
+				DE0DC22F2E0B008F00FF061E /* StringLiterals+PhotoDetail.swift in Sources */,
 				DD9980E02D834F4E00EBBFBC /* PostUserInfoView.swift in Sources */,
 				DD9980E12D834F4E00EBBFBC /* ContentCollectionViewCell.swift in Sources */,
 				DD2968142D6DACF700143851 /* AccountInfo.swift in Sources */,

--- a/Wable-iOS/Core/Literals/String/StringLiterals+PhotoDetail.swift
+++ b/Wable-iOS/Core/Literals/String/StringLiterals+PhotoDetail.swift
@@ -1,0 +1,18 @@
+//
+//  StringLiterals+PhotoDetail.swift
+//  Wable-iOS
+//
+//  Created by 김진웅 on 6/25/25.
+//
+
+import Foundation
+
+extension StringLiterals {
+    
+    // MARK: - PhotoDetail
+
+    enum PhotoDetail {
+        static let successMessage = "사진을 앨범에 저장했습니다."
+        static let errorMessage = "사진 저장에 실패했습니다.\n잠시 후 다시 시도해 주세요."
+    }
+}

--- a/Wable-iOS/Presentation/WableComponent/ViewController/PhotoDetailViewController.swift
+++ b/Wable-iOS/Presentation/WableComponent/ViewController/PhotoDetailViewController.swift
@@ -114,7 +114,13 @@ private extension PhotoDetailViewController {
             do {
                 guard try await requestPhotoPermissionIfNeeded() else { return }
                 try await saveImageToPhotoLibrary(image)
+                await MainActor.run {
+                    ToastView(status: .complete, message: "사진을 앨범에 저장했습니다.").show()
+                }
             } catch {
+                await MainActor.run {
+                    ToastView(status: .error, message: "사진 저장에 실패하였습니다.\n다시 시도해 주세요.").show()
+                }
                 WableLogger.log("\(error)", for: .error)
             }
         }

--- a/Wable-iOS/Presentation/WableComponent/ViewController/PhotoDetailViewController.swift
+++ b/Wable-iOS/Presentation/WableComponent/ViewController/PhotoDetailViewController.swift
@@ -115,11 +115,11 @@ private extension PhotoDetailViewController {
                 guard try await requestPhotoPermissionIfNeeded() else { return }
                 try await saveImageToPhotoLibrary(image)
                 await MainActor.run {
-                    ToastView(status: .complete, message: "사진을 앨범에 저장했습니다.").show()
+                    ToastView(status: .complete, message: StringLiterals.PhotoDetail.successMessage).show()
                 }
             } catch {
                 await MainActor.run {
-                    ToastView(status: .error, message: "사진 저장에 실패하였습니다.\n다시 시도해 주세요.").show()
+                    ToastView(status: .error, message: StringLiterals.PhotoDetail.errorMessage).show()
                 }
                 WableLogger.log("\(error)", for: .error)
             }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 사진 저장 시 결과에 따른 와블 토스트를 보여주도록 구현하였습니다.
- 문구는 따로 TL과 이야기를 나눈 바가 없어, 임의로 구현하였습니다.

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/76a27aaa-5c99-497a-bca5-4aec6111e591" width ="250"> |

## 🔗 연결된 이슈
- Resolved: #240
