### PR TITLE
[Feat] 글 작성 시 화면 상단으로 이동하는 로직 구현

### DIFF
--- a/Wable-iOS.xcodeproj/project.pbxproj
+++ b/Wable-iOS.xcodeproj/project.pbxproj
@@ -3171,7 +3171,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.3.1;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.wable.Wable-iOS.Dev";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.wable.Wable-iOS.dev";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Wable_Debug;
@@ -3200,7 +3200,7 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = HGVD26K7DP;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Wable-iOS/Resource/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "와블";
+				INFOPLIST_KEY_CFBundleDisplayName = "술먹고미친와블";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "게시글이나 프로필을 변경할 때 사용합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;

--- a/Wable-iOS/Presentation/Home/View/HomeViewController.swift
+++ b/Wable-iOS/Presentation/Home/View/HomeViewController.swift
@@ -482,6 +482,7 @@ private extension HomeViewController {
                 )
             )
         )
+        
         viewController.onPostCompleted = { [weak self] in
             self?.scrollToTop()
         }

--- a/Wable-iOS/Presentation/Home/View/WritePostViewController.swift
+++ b/Wable-iOS/Presentation/Home/View/WritePostViewController.swift
@@ -208,6 +208,8 @@ private extension WritePostViewController {
                 self.isPosting = false
                 self.updatePostButtonState(isLoading: false)
                 
+                self.onPostCompleted?()
+                
                 if self.navigationController?.topViewController == self {
                     let toast = ToastView(status: .complete, message: "게시물이 작성되었습니다")
                     toast.show()


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 글 작성 시 화면 상단으로 이동하는 로직을 구현했어요.

|    구현 내용    |   IPhone 15 pro   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/7aae4dfd-87b6-40a0-8ba3-31762a23f252" width ="250"> |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 이미 구현 되어있던데요?? 감사합니다 ㅎㅎ

## 🔗 연결된 이슈
- Resolved: #246


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app display name to "술먹고미친와블" for both debug and release builds.
  * Changed the debug build bundle identifier to use lowercase "dev".

* **Bug Fixes**
  * Ensured post completion actions are triggered immediately after a post is completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->