### PR TITLE
[Refactor] 정기회의 이후 요청사항 적용

### DIFF
--- a/Wable-iOS/Core/Amplitude/AmplitudeManager.swift
+++ b/Wable-iOS/Core/Amplitude/AmplitudeManager.swift
@@ -74,6 +74,7 @@ extension AmplitudeManager {
         case clickNextDeleteguide
         case clickDoneDeleteaccount
         case clickGobackHome
+        case clickDownloadPhoto
         
         var value: String {
             switch self {
@@ -123,6 +124,7 @@ extension AmplitudeManager {
             case .clickNextDeleteguide: return "click_next_deleteguide"
             case .clickDoneDeleteaccount: return "click_done_deleteaccount"
             case .clickGobackHome: return "click_goback_home"
+            case .clickDownloadPhoto: return "click_download_photo"
             }
         }
     }

--- a/Wable-iOS/Core/Literals/String/StringLiterals+Ghost.swift
+++ b/Wable-iOS/Core/Literals/String/StringLiterals+Ghost.swift
@@ -19,6 +19,6 @@ extension StringLiterals {
                                     ex. 선수를 비하했어요
                                     """
         static let completeToast = "덕분에 와블이 더 온화해지고 있어요!"
-        static let tooltip = "투명도란? 설명어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구"
+        static let tooltip = "투명도란? 와블의 건강하고 유쾌한 문화를 유지하기 위한 최소한의 장치입니다. 과도한 혐오나 비방, 조롱을 보게 된다면 투명도를 내려주세요! 클린 LCK 문화 함께 만들어가요."
     }
 }

--- a/Wable-iOS/Presentation/Profile/Component/ProfileInfoCell.swift
+++ b/Wable-iOS/Presentation/Profile/Component/ProfileInfoCell.swift
@@ -268,7 +268,7 @@ private extension ProfileInfoCell {
         ghostInfoTooltip.snp.makeConstraints { make in
             make.top.equalTo(ghostProgressBar.snp.bottom).offset(4)
             make.leading.equalTo(ghostProgressBar)
-            make.trailing.equalToSuperview().offset(-68)
+            make.trailing.equalToSuperview()
         }
         
         badgeTitleLabel.snp.makeConstraints { make in
@@ -309,7 +309,7 @@ private extension ProfileInfoCell {
             showTooltipWithAnimation()
             
             tooltipTimer = Just(())
-                .delay(for: .seconds(3), scheduler: DispatchQueue.main)
+                .delay(for: .seconds(5), scheduler: DispatchQueue.main)
                 .sink { [weak self] _ in self?.hideTooltipWithAnimation() }
         } else {
             hideTooltipWithAnimation()

--- a/Wable-iOS/Presentation/WableComponent/ViewController/PhotoDetailViewController.swift
+++ b/Wable-iOS/Presentation/WableComponent/ViewController/PhotoDetailViewController.swift
@@ -102,6 +102,7 @@ private extension PhotoDetailViewController {
         backButton.addAction(popAction, for: .touchUpInside)
         
         let saveAction = UIAction { [weak self] _ in
+            AmplitudeManager.shared.trackEvent(tag: .clickDownloadPhoto)
             self?.saveImage()
         }
         saveButton.addAction(saveAction, for: .touchUpInside)


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 사진 저장 시, 앰플리튜드 태그를 심었습니다.
- 투명도 안내 문구를 수정했습니다.
- 문구가 길어 레이아웃과 유지 시간을 수정하였습니다.
     - 유지 시간을 늘린 이유는 내용이 길어 3초로는 충분히 읽기가 힘들다고 느껴져서 수정하게 되었습니다.

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 툴팁 | <img src = "https://github.com/user-attachments/assets/f31037a3-5418-463a-9dcc-4fabcce835b6" width ="250"> |

## 🔗 연결된 이슈
- Resolved: #248 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event tracking for photo download button clicks.
* **Improvements**
  * Updated the tooltip message for "투명도" to provide a clearer explanation and encourage positive community behavior.
  * Increased the tooltip display duration from 3 to 5 seconds for better readability.
  * Adjusted tooltip positioning to align with the superview’s trailing edge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->