### PR TITLE
[Add] 변경된 팀 브랜딩에 따른 색상 추가

### DIFF
--- a/Wable-iOS/Resource/Color.xcassets/GrayScale/alpha50.colorset/Contents.json
+++ b/Wable-iOS/Resource/Color.xcassets/GrayScale/alpha50.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.500",
+          "blue" : "0x0E",
+          "green" : "0x0E",
+          "red" : "0x0E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Wable-iOS/Resource/Color.xcassets/Team/bfx10.colorset/Contents.json
+++ b/Wable-iOS/Resource/Color.xcassets/Team/bfx10.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Wable-iOS/Resource/Color.xcassets/Team/bfx50.colorset/Contents.json
+++ b/Wable-iOS/Resource/Color.xcassets/Team/bfx50.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xE4",
+          "red" : "0xFB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Wable-iOS/Resource/Color.xcassets/Team/dnf10.colorset/Contents.json
+++ b/Wable-iOS/Resource/Color.xcassets/Team/dnf10.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xEB",
+          "red" : "0xE2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Wable-iOS/Resource/Color.xcassets/Team/dnf50.colorset/Contents.json
+++ b/Wable-iOS/Resource/Color.xcassets/Team/dnf50.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF2",
+          "green" : "0x50",
+          "red" : "0x0B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 변경된 팀 브랜딩(BFX, DNF)에 따른 팀 색상과 alpha50 색상을 추가하였습니다.

## 🔗 연결된 이슈
- Resolved: #250


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added several new color options to the app’s color palette, including grayscale and team-specific colors, enhancing design flexibility and visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->