### PR TITLE
[Feat] 로그인 에러 토스트 구현, LoginViewModel 메서드 분리 및 코드 리팩토링

### DIFF
--- a/Wable-iOS/App/SceneDelegate.swift
+++ b/Wable-iOS/App/SceneDelegate.swift
@@ -20,13 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     private let loginRepository = LoginRepositoryImpl()
     private let profileRepository = ProfileRepositoryImpl()
-    private let userSessionRepository = UserSessionRepositoryImpl(
-        userDefaults: UserDefaultsStorage(
-            userDefaults: UserDefaults.standard,
-            jsonEncoder: JSONEncoder(),
-            jsonDecoder: JSONDecoder()
-        )
-    )
+    private let userSessionRepository = UserSessionRepositoryImpl(userDefaults: UserDefaultsStorage())
     private let checkAppUpdateRequirementUseCase = CheckAppUpdateRequirementUseCaseImpl()
     
     // MARK: - UIComponent
@@ -66,17 +60,20 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 private extension SceneDelegate {
     func configureLoginScreen() {
+        let userProfileUseCase = UserProfileUseCase(repository: ProfileRepositoryImpl())
+        let fetchUserAuthUseCase = FetchUserAuthUseCase(
+            loginRepository: loginRepository,
+            userSessionRepository: userSessionRepository
+        )
+        let updateFCMTokenUseCase = UpdateFCMTokenUseCase(repository: ProfileRepositoryImpl())
+        let updateUserSessionUseCase = FetchUserInformationUseCase(repository: userSessionRepository)
+        
         self.window?.rootViewController = LoginViewController(
             viewModel: LoginViewModel(
-                updateFCMTokenUseCase: UpdateFCMTokenUseCase(
-                    repository: ProfileRepositoryImpl()
-                ),
-                fetchUserAuthUseCase: FetchUserAuthUseCase(
-                    loginRepository: loginRepository,
-                    userSessionRepository: userSessionRepository
-                ),
-                updateUserSessionUseCase: FetchUserInformationUseCase(repository: userSessionRepository),
-                userProfileUseCase: UserProfileUseCase(repository: ProfileRepositoryImpl())
+                userProfileUseCase: userProfileUseCase,
+                fetchUserAuthUseCase: fetchUserAuthUseCase,
+                updateFCMTokenUseCase: updateFCMTokenUseCase,
+                updateUserSessionUseCase: updateUserSessionUseCase
             )
         )
     }

--- a/Wable-iOS/Domain/Error/WableError.swift
+++ b/Wable-iOS/Domain/Error/WableError.swift
@@ -34,8 +34,8 @@ enum WableError: String, Error {
     case notFoundComment = "해당하는 답글이 없습니다."
     case unauthorizedMember = "권한이 없는 유저입니다."
     case unauthorizedToken = "유효하지 않은 토큰입니다."
-    case kakaoUnauthorizedUser = "카카오 로그인 실패. 만료되었거나 잘못된 카카오 토큰입니다."
-    case failedToValidateAppleLogin = "애플 로그인 실패. 만료되었거나 잘못된 애플 토큰입니다."
+    case failedToKakaoLogin = "카카오 로그인 실패. 작업이 취소되었거나 토큰 오류입니다."
+    case failedToAppleLogin = "애플 로그인 실패. 작업이 취소되었거나 토큰 오류입니다."
     case signinRequired = "access, refreshToken 모두 만료되었습니다. 재로그인이 필요합니다."
     case validAccessToken = "아직 유효한 accessToken 입니다."
     

--- a/Wable-iOS/Domain/UseCase/Onboarding/UpdateFCMTokenUseCase.swift
+++ b/Wable-iOS/Domain/UseCase/Onboarding/UpdateFCMTokenUseCase.swift
@@ -20,10 +20,7 @@ final class UpdateFCMTokenUseCase {
 
 extension UpdateFCMTokenUseCase {
     func execute(nickname: String) -> AnyPublisher<Void, WableError> {
-        guard let token = repository.fetchFCMToken() else {
-            return .fail(WableError.noToken)
-        }
-        
+        guard let token = repository.fetchFCMToken() else { return .fail(WableError.noToken) }
         return repository.updateUserProfile(nickname: nickname, fcmToken: token)
     }
 }

--- a/Wable-iOS/Domain/UseCase/Onboarding/UserProfileUseCase.swift
+++ b/Wable-iOS/Domain/UseCase/Onboarding/UserProfileUseCase.swift
@@ -18,7 +18,13 @@ final class UserProfileUseCase {
 }
 
 extension UserProfileUseCase {
-    func execute(profile: UserProfile? = nil, isPushAlarmAllowed: Bool? = nil, isAlarmAllowed: Bool? = nil, image: UIImage? = nil, defaultProfileType: String? = nil) -> AnyPublisher<Void, WableError> {
+    func execute(
+        profile: UserProfile? = nil,
+        isPushAlarmAllowed: Bool? = nil,
+        isAlarmAllowed: Bool? = nil,
+        image: UIImage? = nil,
+        defaultProfileType: String? = nil
+    ) -> AnyPublisher<Void, WableError> {
         return repository.updateUserProfile(
             profile: profile,
             isPushAlarmAllowed: isPushAlarmAllowed,
@@ -31,5 +37,28 @@ extension UserProfileUseCase {
     
     func execute(userID: Int) -> AnyPublisher<UserProfile, WableError> {
         return repository.fetchUserProfile(memberID: userID)
+    }
+    
+    func updateProfile(
+        userID: Int,
+        isPushAlarmAllowed: Bool? = nil,
+        isAlarmAllowed: Bool? = nil,
+        image: UIImage? = nil,
+        defaultProfileType: String? = nil
+    ) -> AnyPublisher<Void, WableError> {
+        let fetchProfile = repository.fetchUserProfile(memberID: userID)
+        let updateProfile = { [weak self] (profile: UserProfile) -> AnyPublisher<Void, WableError> in
+            guard let self = self else { return Fail(error: WableError.unknownError).eraseToAnyPublisher() }
+            
+            return self.execute(
+                profile: profile,
+                isPushAlarmAllowed: isPushAlarmAllowed,
+                isAlarmAllowed: isAlarmAllowed,
+                image: image,
+                defaultProfileType: defaultProfileType
+            )
+        }
+        
+        return fetchProfile.flatMap(updateProfile).eraseToAnyPublisher()
     }
 }

--- a/Wable-iOS/Domain/UseCase/Onboarding/UserProfileUseCase.swift
+++ b/Wable-iOS/Domain/UseCase/Onboarding/UserProfileUseCase.swift
@@ -18,8 +18,8 @@ final class UserProfileUseCase {
 }
 
 extension UserProfileUseCase {
-    func execute(
-        profile: UserProfile? = nil,
+    func updateProfile(
+        profile: UserProfile?,
         isPushAlarmAllowed: Bool? = nil,
         isAlarmAllowed: Bool? = nil,
         image: UIImage? = nil,
@@ -35,11 +35,11 @@ extension UserProfileUseCase {
         )
     }
     
-    func execute(userID: Int) -> AnyPublisher<UserProfile, WableError> {
+    func fetchProfile(userID: Int) -> AnyPublisher<UserProfile, WableError> {
         return repository.fetchUserProfile(memberID: userID)
     }
     
-    func updateProfile(
+    func updateProfileWithUserID(
         userID: Int,
         isPushAlarmAllowed: Bool? = nil,
         isAlarmAllowed: Bool? = nil,
@@ -50,7 +50,7 @@ extension UserProfileUseCase {
         let updateProfile = { [weak self] (profile: UserProfile) -> AnyPublisher<Void, WableError> in
             guard let self = self else { return Fail(error: WableError.unknownError).eraseToAnyPublisher() }
             
-            return self.execute(
+            return self.updateProfile(
                 profile: profile,
                 isPushAlarmAllowed: isPushAlarmAllowed,
                 isAlarmAllowed: isAlarmAllowed,

--- a/Wable-iOS/Infra/Auth/AppleAuthProvider.swift
+++ b/Wable-iOS/Infra/Auth/AppleAuthProvider.swift
@@ -57,7 +57,7 @@ extension AppleAuthProvider: ASAuthorizationControllerDelegate {
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         guard let promise = self.promise else { return }
         
-        promise(.failure(.failedToValidateAppleLogin))
+        promise(.failure(.failedToAppleLogin))
     }
 }
 

--- a/Wable-iOS/Infra/Auth/KakaoAuthProvider.swift
+++ b/Wable-iOS/Infra/Auth/KakaoAuthProvider.swift
@@ -41,12 +41,12 @@ private extension KakaoAuthProvider {
         promise: @escaping (Result<String?, WableError>) -> Void
     ) {
         if error != nil {
-            promise(.failure(.kakaoUnauthorizedUser))
+            promise(.failure(.failedToKakaoLogin))
             return
         }
         
         guard let token = oauthToken?.accessToken else {
-            promise(.failure(.kakaoUnauthorizedUser))
+            promise(.failure(.failedToKakaoLogin))
             return
         }
         

--- a/Wable-iOS/Infra/Local/UserDefaultsStorage.swift
+++ b/Wable-iOS/Infra/Local/UserDefaultsStorage.swift
@@ -13,7 +13,11 @@ struct UserDefaultsStorage {
     private let jsonEncoder: JSONEncoder
     private let jsonDecoder: JSONDecoder
     
-    init(userDefaults: UserDefaults = .standard, jsonEncoder: JSONEncoder, jsonDecoder: JSONDecoder) {
+    init(
+        userDefaults: UserDefaults = .standard,
+        jsonEncoder: JSONEncoder = JSONEncoder(),
+        jsonDecoder: JSONDecoder = JSONDecoder()
+    ) {
         self.userDefaults = userDefaults
         self.jsonEncoder = jsonEncoder
         self.jsonDecoder = jsonDecoder

--- a/Wable-iOS/Presentation/Login/LoginViewController.swift
+++ b/Wable-iOS/Presentation/Login/LoginViewController.swift
@@ -156,11 +156,22 @@ private extension LoginViewController {
             .sink { owner, sessionInfo in
                 let condition = sessionInfo.isNewUser || sessionInfo.user.nickname == ""
                 
-                if condition {
-                    AmplitudeManager.shared.trackEvent(tag: .clickAgreePopupSignup)
-                }
-                
+                if condition { AmplitudeManager.shared.trackEvent(tag: .clickAgreePopupSignup) }
                 condition ? owner.navigateToOnboarding() : owner.navigateToHome()
+            }
+            .store(in: cancelBag)
+        
+        output.error
+            .receive(on: DispatchQueue.main)
+            .withUnretained(self)
+            .sink { owner, error in
+                let toast = WableSheetViewController(
+                    title: "로그인 중 오류가 발생했어요",
+                    message: "\(error.localizedDescription)\n다시 시도해주세요."
+                )
+                
+                toast.addAction(.init(title: "확인", style: .primary))
+                owner.present(toast, animated: true)
             }
             .store(in: cancelBag)
     }

--- a/Wable-iOS/Presentation/Login/LoginViewModel.swift
+++ b/Wable-iOS/Presentation/Login/LoginViewModel.swift
@@ -46,6 +46,7 @@ extension LoginViewModel: ViewModelType {
     
     struct Output {
         let account: AnyPublisher<Account, Never>
+        let error: AnyPublisher<WableError, Never>
     }
     
     func transform(input: Input, cancelBag: CancelBag) -> Output {
@@ -60,7 +61,7 @@ extension LoginViewModel: ViewModelType {
                 return owner.fetchUserAuthUseCase.execute(platform: flatform)
                     .handleEvents(receiveCompletion: { completion in
                         if case .failure(let error) = completion {
-                            WableLogger.log("로그인 중 오류 발생: \(error)", for: .error)
+                            owner.loginErrorSubject.send(error)
                         }
                     })
                     .catch { error -> AnyPublisher<Account, Never> in
@@ -130,7 +131,8 @@ extension LoginViewModel: ViewModelType {
             .store(in: cancelBag)
         
         return Output(
-            account: loginSuccessSubject.eraseToAnyPublisher()
+            account: loginSuccessSubject.eraseToAnyPublisher(),
+            error: loginErrorSubject.eraseToAnyPublisher()
         )
     }
 }

--- a/Wable-iOS/Presentation/Login/LoginViewModel.swift
+++ b/Wable-iOS/Presentation/Login/LoginViewModel.swift
@@ -72,6 +72,8 @@ extension LoginViewModel: ViewModelType {
     }
 }
 
+// MARK: - Helper Method
+
 private extension LoginViewModel {
     func fetchUserAuth(platform: SocialPlatform) -> AnyPublisher<Account, Never> {
         return fetchUserAuthUseCase.execute(platform: platform)

--- a/Wable-iOS/Presentation/Login/LoginViewModel.swift
+++ b/Wable-iOS/Presentation/Login/LoginViewModel.swift
@@ -101,7 +101,7 @@ private extension LoginViewModel {
             let authorizedStatus = await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
             let isAuthorized = authorizedStatus == .authorized
             
-            self.userProfileUseCase.updateProfile(userID: userID, isPushAlarmAllowed: isAuthorized)
+            self.userProfileUseCase.updateProfileWithUserID(userID: userID, isPushAlarmAllowed: isAuthorized)
                 .catch { error -> AnyPublisher<Void, Never> in
                     self.loginErrorSubject.send(error)
                     return .just(())

--- a/Wable-iOS/Presentation/Onboarding/ViewController/AgreementViewController.swift
+++ b/Wable-iOS/Presentation/Onboarding/ViewController/AgreementViewController.swift
@@ -154,7 +154,7 @@ private extension AgreementViewController {
                 userSession in
                 guard let userSession = userSession else { return }
                 
-                owner.profileUseCase.execute(
+                owner.profileUseCase.updateProfile(
                     profile: UserProfile(
                         user: User(
                             id: userSession.id,

--- a/Wable-iOS/Presentation/Profile/Edit/ProfileEditViewController.swift
+++ b/Wable-iOS/Presentation/Profile/Edit/ProfileEditViewController.swift
@@ -116,7 +116,7 @@ private extension ProfileEditViewController {
                 if hasNicknameChanged || hasImageChanged || hasTeamChanged {
                     let finalNickname = hasNicknameChanged ? nicknameText : profile.user.nickname
                     
-                    profileUseCase.execute(
+                    profileUseCase.updateProfile(
                         profile: UserProfile(
                             user: User(
                                 id: profile.user.id,
@@ -169,7 +169,7 @@ private extension ProfileEditViewController {
         if hasNicknameChanged || hasImageChanged || hasTeamChanged {
             let finalNickname = hasNicknameChanged ? nicknameText : profile.user.nickname
             
-            profileUseCase.execute(
+            profileUseCase.updateProfile(
                 profile: UserProfile(
                     user: User(
                         id: profile.user.id,
@@ -290,7 +290,7 @@ extension ProfileEditViewController {
                 guard let self = self,
                       let sessionID = sessionID else { return }
                 
-                profileUseCase.execute(userID: sessionID)
+                profileUseCase.fetchProfile(userID: sessionID)
                     .receive(on: DispatchQueue.main)
                     .sink { _ in } receiveValue: { [weak self] profile in
                         guard let self = self else { return }

--- a/Wable-iOS/Presentation/Profile/My/View/MyProfileViewController.swift
+++ b/Wable-iOS/Presentation/Profile/My/View/MyProfileViewController.swift
@@ -465,23 +465,23 @@ private extension MyProfileViewController {
             return WableLogger.log("SceneDelegate 찾을 수 없음.", for: .debug)
         }
         
+        let userSessionRepository = UserSessionRepositoryImpl(userDefaults: UserDefaultsStorage(
+            jsonEncoder: .init(),
+            jsonDecoder: .init()
+        ))
+        let userProfileUseCase = UserProfileUseCase(repository: ProfileRepositoryImpl())
+        let fetchUserAuthUseCase = FetchUserAuthUseCase(
+            loginRepository: LoginRepositoryImpl(),
+            userSessionRepository: userSessionRepository
+        )
+        let updateFCMTokenUseCase = UpdateFCMTokenUseCase(repository: ProfileRepositoryImpl())
+        let updateUserSessionUseCase = FetchUserInformationUseCase(repository: userSessionRepository)
         let loginViewController = LoginViewController(
             viewModel: .init(
-                updateFCMTokenUseCase: UpdateFCMTokenUseCase(
-                    repository: ProfileRepositoryImpl()
-                ),
-                fetchUserAuthUseCase: FetchUserAuthUseCase(
-                    loginRepository: LoginRepositoryImpl(),
-                    userSessionRepository: UserSessionRepositoryImpl(
-                        userDefaults: UserDefaultsStorage(jsonEncoder: .init(), jsonDecoder: .init())
-                    )
-                ),
-                updateUserSessionUseCase: FetchUserInformationUseCase(
-                    repository: UserSessionRepositoryImpl(
-                        userDefaults: UserDefaultsStorage(jsonEncoder: .init(), jsonDecoder: .init())
-                    )
-                ),
-                userProfileUseCase: UserProfileUseCase(repository: ProfileRepositoryImpl())
+                userProfileUseCase: userProfileUseCase,
+                fetchUserAuthUseCase: fetchUserAuthUseCase,
+                updateFCMTokenUseCase: updateFCMTokenUseCase,
+                updateUserSessionUseCase: updateUserSessionUseCase
             )
         )
         

--- a/Wable-iOS/Presentation/Profile/Withdrawal/Guide/View/WithdrawalGuideViewController.swift
+++ b/Wable-iOS/Presentation/Profile/Withdrawal/Guide/View/WithdrawalGuideViewController.swift
@@ -99,23 +99,20 @@ private extension WithdrawalGuideViewController {
             return WableLogger.log("SceneDelegate 찾을 수 없음.", for: .debug)
         }
         
+        let userSessionRepository = UserSessionRepositoryImpl(userDefaults: UserDefaultsStorage())
+        let userProfileUseCase = UserProfileUseCase(repository: ProfileRepositoryImpl())
+        let fetchUserAuthUseCase = FetchUserAuthUseCase(
+            loginRepository: LoginRepositoryImpl(),
+            userSessionRepository: userSessionRepository
+        )
+        let updateFCMTokenUseCase = UpdateFCMTokenUseCase(repository: ProfileRepositoryImpl())
+        let updateUserSessionUseCase = FetchUserInformationUseCase(repository: userSessionRepository)
         let loginViewController = LoginViewController(
             viewModel: .init(
-                updateFCMTokenUseCase: UpdateFCMTokenUseCase(
-                    repository: ProfileRepositoryImpl()
-                ),
-                fetchUserAuthUseCase: FetchUserAuthUseCase(
-                    loginRepository: LoginRepositoryImpl(),
-                    userSessionRepository: UserSessionRepositoryImpl(
-                        userDefaults: UserDefaultsStorage(jsonEncoder: .init(), jsonDecoder: .init())
-                    )
-                ),
-                updateUserSessionUseCase: FetchUserInformationUseCase(
-                    repository: UserSessionRepositoryImpl(
-                        userDefaults: UserDefaultsStorage(jsonEncoder: .init(), jsonDecoder: .init())
-                    )
-                ),
-                userProfileUseCase: UserProfileUseCase(repository: ProfileRepositoryImpl())
+                userProfileUseCase: userProfileUseCase,
+                fetchUserAuthUseCase: fetchUserAuthUseCase,
+                updateFCMTokenUseCase: updateFCMTokenUseCase,
+                updateUserSessionUseCase: updateUserSessionUseCase
             )
         )
         


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 로그인 중 에러 발생 시 토스트가 뜨도록 구현했어요.
- `UserDefaultsStorage`의 생성자에서 `JSONEncoder`, `JSONDecoder`를 선택적으로 명시할 수 있도록 리팩토링을 진행했어요.
- 가독성을 위해 `LoginViewModel`에서 기능별 메서드 분리를 진행했어요.
- 로그인 실패 시 유저에게 더 친숙한 문장이 표시되도록 `WableError`의 카카오, 애플 로그인 관련 `case`의 네이밍과 `description`을 수정했어요.

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### UserProfileUseCase 메서드 수정
- 기존 UserProfileUseCase에서는 profile 정보를 받아오는 메서드, profile 정보를 업데이트하는 메서드만 구현되어 있었습니다.
- Presentation 레이어에서 유저의 profile 정보를 업데이트하기 위해서는 profile 프로퍼티를 필요로 하는데, 이를 가져오기 위해서는 같은 useCase 내에 있는 정보 불러오기 execute 메서드를 실행 후, 해당 정보를 가지고 정보 업데이트 execute 메서드를 연속적으로 실행해야 해 불편하고 비효율적인 코드가 구현되었습니다.
- 따라서 메서드명을 각각 updateProfile, fetchProfile로 변경하고 updateProfile 내에서는 자체적으로 레포지토리에서 유저 프로필을 받아오도록 구현해 Presentation 레이어에서 불필요한 작업을 실행하지 않아도 되도록 리팩토링을 진행했습니다.

```swift
 func updateProfileWithUserID(
        userID: Int,
        isPushAlarmAllowed: Bool? = nil,
        isAlarmAllowed: Bool? = nil,
        image: UIImage? = nil,
        defaultProfileType: String? = nil
    ) -> AnyPublisher<Void, WableError> {
        let fetchProfile = repository.fetchUserProfile(memberID: userID)
        let updateProfile = { [weak self] (profile: UserProfile) -> AnyPublisher<Void, WableError> in
            guard let self = self else { return Fail(error: WableError.unknownError).eraseToAnyPublisher() }

            return self.execute(
                profile: profile,
                isPushAlarmAllowed: isPushAlarmAllowed,
                isAlarmAllowed: isAlarmAllowed,
                image: image,
                defaultProfileType: defaultProfileType
            )
        }

        return fetchProfile.flatMap(updateProfile).eraseToAnyPublisher()
    }
```

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 해당 PR 머지 후 계정 정보 수정해 재심사 올리겠습니다 ~!

## 🔗 연결된 이슈
- Resolved: #252 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit error handling for login failures, now displaying user-friendly error messages via modal toasts during login.

* **Bug Fixes**
  * Improved error messages for Kakao and Apple login failures to provide clearer feedback to users.

* **Refactor**
  * Streamlined login and profile update flows for better maintainability and code clarity.
  * Updated method names in the profile management features for improved semantic clarity.
  * Reduced redundant instantiations of repositories and storage components across multiple screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->