### PR TITLE
[Fix] 알림 목록 중 프로필 관련 터치 이벤트

### DIFF
--- a/Wable-iOS/Presentation/Notification/Activity/View/ActivityNotificationViewController.swift
+++ b/Wable-iOS/Presentation/Notification/Activity/View/ActivityNotificationViewController.swift
@@ -21,7 +21,7 @@ final class ActivityNotificationViewController: UIViewController {
     }
     
     // MARK: - typealias
-
+    
     typealias Item = ActivityNotification
     typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
     typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Item>
@@ -48,7 +48,7 @@ final class ActivityNotificationViewController: UIViewController {
     }
     
     // MARK: - Property
-
+    
     private var dataSource: DataSource?
     
     private let viewModel: ViewModel
@@ -268,11 +268,23 @@ private extension ActivityNotificationViewController {
         
         output.user
             .receive(on: DispatchQueue.main)
-            .sink { userID in
-                WableLogger.log("유저 아이디: \(userID)", for: .debug)
+            .sink { [weak self] userID in
+                let otherProfileViewController = OtherProfileViewController(
+                    viewModel: .init(
+                        userID: userID,
+                        fetchUserProfileUseCase: FetchUserProfileUseCaseImpl(),
+                        checkUserRoleUseCase: CheckUserRoleUseCaseImpl(
+                            repository: UserSessionRepositoryImpl(
+                                userDefaults: UserDefaultsStorage(
+                                    jsonEncoder: JSONEncoder(),
+                                    jsonDecoder: JSONDecoder()
+                                )
+                            )
+                        )
+                    )
+                )
                 
-                // TODO: 유저 프로필로 이동
-                
+                self?.navigationController?.pushViewController(otherProfileViewController, animated: true)
             }
             .store(in: cancelBag)
     }

--- a/Wable-iOS/Presentation/Notification/Activity/ViewModel/ActivityNotificationViewModel.swift
+++ b/Wable-iOS/Presentation/Notification/Activity/ViewModel/ActivityNotificationViewModel.swift
@@ -155,8 +155,13 @@ extension ActivityNotificationViewModel: ViewModelType {
         
         let user = input.profileImageViewDidTap
             .filter { $0 < notificationsSubject.value.count }
-            .map { notificationsSubject.value[$0] }
-            .map { $0.triggerUserID }
+            .filter { 
+                guard let type = notificationsSubject.value[$0].type else {
+                    return false
+                }
+                return TriggerType.ActivityNotification.profileInteractionTypes.contains(type)
+             }
+            .map { notificationsSubject.value[$0].triggerUserID }
             .eraseToAnyPublisher()
         
         return Output(

--- a/Wable-iOS/Presentation/Notification/Activity/ViewModel/ActivityNotificationViewModel.swift
+++ b/Wable-iOS/Presentation/Notification/Activity/ViewModel/ActivityNotificationViewModel.swift
@@ -156,9 +156,7 @@ extension ActivityNotificationViewModel: ViewModelType {
         let user = input.profileImageViewDidTap
             .filter { $0 < notificationsSubject.value.count }
             .filter { 
-                guard let type = notificationsSubject.value[$0].type else {
-                    return false
-                }
+                guard let type = notificationsSubject.value[$0].type else { return false }
                 return TriggerType.ActivityNotification.profileInteractionTypes.contains(type)
              }
             .map { notificationsSubject.value[$0].triggerUserID }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 알림 목록 중 프로필 이미지 터치 이벤트 대응 코드를 작성하였습니다.

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/b3f85298-a2cf-4700-9534-a882dc94a8ed" width ="250"> |

## 🔗 연결된 이슈
- Resolved: #271 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 활동 알림에서 프로필 이미지 탭 시 상대 프로필 화면으로 바로 이동하도록 네비게이션을 추가했습니다.
  - 관련 뷰모델 연동으로 사용자 ID 기반 프로필 로딩 및 권한 체크를 지원합니다.
- 버그 수정
  - 프로필 이미지 탭 이벤트에 알림 타입 검증을 도입해 지정된 상호작용 타입에서만 동작하도록 했습니다.
  - 타입 누락·부적합 상황을 필터링해 의도치 않은 화면 이동을 방지했습니다.
- 스타일
  - 타입별 선언부 등 경미한 코드 정리를 통해 가독성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->