### PR TITLE
[Refactor] 로그인 화면 코디네이터 패턴 적용

### DIFF
--- a/Wable-iOS.xcodeproj/project.pbxproj
+++ b/Wable-iOS.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 		DD9EAE282D99C7DE00803A1A /* DeleteContentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9EAE272D99C7D200803A1A /* DeleteContentUseCase.swift */; };
 		DD9EAE2E2D9A63FD00803A1A /* WritePostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9EAE2D2D9A63F400803A1A /* WritePostViewController.swift */; };
 		DD9EAE302D9A64A800803A1A /* HomeDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9EAE2F2D9A649D00803A1A /* HomeDetailViewController.swift */; };
+		DDA138D82E84235600F7B63C /* LoginCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA138D72E84235600F7B63C /* LoginCoordinator.swift */; };
 		DDA2098D2D9BFB9F008042DA /* WritePostViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA2098C2D9BFB98008042DA /* WritePostViewModel.swift */; };
 		DDCA70902D87CE2700A988B8 /* LCKYearViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCA708F2D87CE0500A988B8 /* LCKYearViewController.swift */; };
 		DDCA70932D88316200A988B8 /* LCKYearView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCA70922D88315C00A988B8 /* LCKYearView.swift */; };
@@ -565,6 +566,7 @@
 		DD9EAE272D99C7D200803A1A /* DeleteContentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteContentUseCase.swift; sourceTree = "<group>"; };
 		DD9EAE2D2D9A63F400803A1A /* WritePostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritePostViewController.swift; sourceTree = "<group>"; };
 		DD9EAE2F2D9A649D00803A1A /* HomeDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDetailViewController.swift; sourceTree = "<group>"; };
+		DDA138D72E84235600F7B63C /* LoginCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCoordinator.swift; sourceTree = "<group>"; };
 		DDA2098C2D9BFB98008042DA /* WritePostViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritePostViewModel.swift; sourceTree = "<group>"; };
 		DDCA708F2D87CE0500A988B8 /* LCKYearViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCKYearViewController.swift; sourceTree = "<group>"; };
 		DDCA70922D88315C00A988B8 /* LCKYearView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCKYearView.swift; sourceTree = "<group>"; };
@@ -1303,6 +1305,7 @@
 			children = (
 				DD4AFD442D8FF19B00D56B94 /* LoginViewModel.swift */,
 				DD765D992D8746DD0029A317 /* LoginViewController.swift */,
+				DDA138D72E84235600F7B63C /* LoginCoordinator.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -2948,6 +2951,7 @@
 				DD9EAE2E2D9A63FD00803A1A /* WritePostViewController.swift in Sources */,
 				DD51A44C2DD458A8004295B6 /* ProfileEditViewController.swift in Sources */,
 				DD2967FF2D6DAC8900143851 /* SceneDelegate.swift in Sources */,
+				DDA138D82E84235600F7B63C /* LoginCoordinator.swift in Sources */,
 				DD2968172D6DAD0200143851 /* ContentRepository.swift in Sources */,
 				DDED595E2D78C3E000A0BEF1 /* KakaoAuthProvider.swift in Sources */,
 				DD2968182D6DAD0200143851 /* CommunityRepository.swift in Sources */,

--- a/Wable-iOS/App/SceneDelegate.swift
+++ b/Wable-iOS/App/SceneDelegate.swift
@@ -23,6 +23,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     private let userSessionRepository = UserSessionRepositoryImpl(userDefaults: UserDefaultsStorage())
     private let checkAppUpdateRequirementUseCase = CheckAppUpdateRequirementUseCaseImpl()
     
+    private var loginCoordinator: LoginCoordinator?
+    
     // MARK: - UIComponent
     
     var window: UIWindow?
@@ -60,7 +62,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 private extension SceneDelegate {
     func configureLoginScreen() {
-        self.window?.rootViewController = LoginViewController(viewModel: LoginViewModel())
+        let navigationController = UINavigationController()
+        navigationController.navigationBar.isHidden = true
+        loginCoordinator = LoginCoordinator(navigationController: navigationController)
+        loginCoordinator?.start()
+        self.window?.rootViewController = navigationController
     }
     
     func configureMainScreen() {

--- a/Wable-iOS/Presentation/Login/LoginCoordinator.swift
+++ b/Wable-iOS/Presentation/Login/LoginCoordinator.swift
@@ -1,0 +1,50 @@
+import UIKit
+
+final class LoginCoordinator: Coordinator {
+    var childCoordinators: [Coordinator] = []
+    var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func start() {
+        let viewModel = LoginViewModel()
+        let viewController = LoginViewController(viewModel: viewModel)
+        
+        viewController.navigateToOnboarding = { [weak self] in
+            self?.showOnboarding()
+        }
+        
+        viewController.navigateToHome = { [weak self] in
+            self?.showHome()
+        }
+        
+        navigationController.setViewControllers([viewController], animated: false)
+    }
+}
+
+private extension LoginCoordinator {
+    func showOnboarding() {
+        let noticeViewController = WableSheetViewController(
+            title: "앗 잠깐!",
+            message: StringLiterals.Onboarding.enterSheetTitle
+        )
+        
+        noticeViewController.addAction(.init(title: "확인", style: .primary, handler: { [weak self] in
+            let onboardingNavigationController = UINavigationController(rootViewController: LCKYearViewController(type: .flow))
+            onboardingNavigationController.navigationBar.isHidden = true
+            onboardingNavigationController.modalPresentationStyle = .fullScreen
+            
+            self?.navigationController.present(onboardingNavigationController, animated: true)
+        }))
+        
+        navigationController.present(noticeViewController, animated: true)
+    }
+    
+    func showHome() {
+        let tabBarController = TabBarController()
+        tabBarController.modalPresentationStyle = .fullScreen
+        navigationController.present(tabBarController, animated: true)
+    }
+}

--- a/Wable-iOS/Presentation/Login/LoginViewController.swift
+++ b/Wable-iOS/Presentation/Login/LoginViewController.swift
@@ -17,6 +17,9 @@ final class LoginViewController: UIViewController {
     private let viewModel: LoginViewModel
     private let cancelBag = CancelBag()
     
+    var navigateToOnboarding: (() -> Void)?
+    var navigateToHome: (() -> Void)?
+    
     // MARK: UIComponent
     
     private let backgroundImageView: UIImageView = UIImageView(image: .imgLoginBackground).then {
@@ -152,7 +155,7 @@ private extension LoginViewController {
                 let condition = sessionInfo.isNewUser || sessionInfo.user.nickname == ""
                 
                 if condition { AmplitudeManager.shared.trackEvent(tag: .clickAgreePopupSignup) }
-                condition ? owner.navigateToOnboarding() : owner.navigateToHome()
+                condition ? owner.navigateToOnboarding?() : owner.navigateToHome?()
             }
             .store(in: cancelBag)
         
@@ -171,32 +174,3 @@ private extension LoginViewController {
             .store(in: cancelBag)
     }
 }
-
-// MARK: - Helper Method
-
-private extension LoginViewController {
-    func navigateToOnboarding() {
-        let noticeViewController = WableSheetViewController(
-            title: "앗 잠깐!",
-            message: StringLiterals.Onboarding.enterSheetTitle
-        )
-        
-        noticeViewController.addAction(.init(title: "확인", style: .primary, handler: {
-            let navigationController = UINavigationController(rootViewController: LCKYearViewController(type: .flow)).then {
-                $0.navigationBar.isHidden = true
-                $0.modalPresentationStyle = .fullScreen
-            }
-            
-            self.present(navigationController, animated: true)
-        }))
-        
-        present(noticeViewController, animated: true)
-    }
-    
-    func navigateToHome() {
-        let tabBarController = TabBarController()
-        
-        present(tabBarController, animated: true)
-    }
-}
-


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- `SceneDelegate`, `LoginViewController`에 코디네이터 패턴을 적용헸어요.

## ✅ 이번 PR에서 이런 부분을 중점적으로 체크해주세요!
<!-- 해당 토글 내에 있는 항목 중 리뷰어가 중점적으로 봐주었으면 하는 부분은 토글 밖으로 이동해주세요. -->
<!-- 해당 토글 내에 있는 항목이 아니더라도 중점적으로 봐주었으면 하는 부분이 있다면 자유롭게 추가해주세요. -->
<!-- 토글 내에 있는 항목들은 PR 게시 전 점검해주세요! -->

<details>
<summary>잠깐 확인하고 갈까요?</summary>

- 들여쓰기를 5번 이하로 준수했는지, 코드 가독성이 적절한지 확인해주세요.
- 한 줄당 120자 제한을 준수했는지 확인해주세요.
- MARK 주석이 정해진 순서와 형식에 맞게 작성되었는지 확인해주세요.

- 반복되는 상수 값이 있는지, 있다면 Constant enum으로 분리되어 있는지 확인해주세요.
- 삼항 연산자가 길어질 경우 적절히 개행되어 있는지 확인해주세요.
- 조건문에서 중괄호가 올바르게 사용되었는지 확인해주세요.
- 라이브러리 import가 퍼스트파티와 서드파티로 구분되고 알파벳순으로 정렬되었는지 확인해주세요.

- 용량이 큰 리소스나 호출되지 않을 가능성이 있는 프로퍼티에 lazy var가 적절히 사용되었는지 확인해주세요.
- 메모리 누수 방지를 위한 weak 참조가 필요한 곳에 적용되었는지 확인해주세요.
- 도메인 로직과 UI 로직이 적절히 분리되어 있는지 확인해주세요.

</details>


## 🔗 연결된 이슈
- Resolved: #278 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 로그인 진입 시 온보딩 안내 시트가 표시되어 사용자가 확인 후 온보딩으로 이동합니다.
  - 온보딩 및 홈 화면이 전체 화면 전환으로 표시되어 몰입감이 향상됩니다.
- 리팩터링
  - 로그인 흐름을 코디네이터 기반으로 재구성하여 내비게이션 바를 숨기고 전환 동작을 일관되게 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->