### PR TITLE
[Fix] 계정 정보 화면 앱 버전 표시 방식 변경

### DIFF
--- a/Wable-iOS/Presentation/Profile/AccountInfo/ViewModel/AccountInfoViewModel.swift
+++ b/Wable-iOS/Presentation/Profile/AccountInfo/ViewModel/AccountInfoViewModel.swift
@@ -12,6 +12,8 @@ final class AccountInfoViewModel {
     @Published private(set) var items: [AccountInfoCellItem] = []
     @Published private(set) var errorMessage: String?
     
+    @Injected private var appVersionRepository: AppVersionRepository
+    
     private let useCase: FetchAccountInfoUseCase
     
     init(useCase: FetchAccountInfoUseCase) {
@@ -19,12 +21,13 @@ final class AccountInfoViewModel {
     }
     
     func viewDidLoad() {
+        let currentAppVersion = appVersionRepository.fetchCurrentVersion().description
         Task {
             do {
                 let accountInfo = try await useCase.execute()
                 items = [
                     .init(title: "소셜 로그인", description: accountInfo.socialPlatform?.rawValue ?? ""),
-                    .init(title: "버전 정보", description: accountInfo.version),
+                    .init(title: "버전 정보", description: currentAppVersion),
                     .init(title: "아이디", description: accountInfo.displayMemberID),
                     .init(title: "가입일", description: formatDate(accountInfo.createdDate ?? .now)),
                     .init(title: "이용약관", description: "자세히 보기", isUserInteractive: true)


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 계정 정보 화면에서 서버로부터 전달받았던 방식을 변경하였습니다.

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 계정 정보 | <img src = "https://github.com/user-attachments/assets/be783eed-b694-4786-a875-ec1a8dd77fb3" width ="250"> |


## 🔗 연결된 이슈
- Resolved: #285 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 계정 정보 화면의 “버전 정보”가 앱의 실제 현재 버전을 정확히 표시하도록 수정했습니다. 이전에 버전 값이 일치하지 않거나 최신 상태가 반영되지 않던 경우를 개선했습니다. 이제 앱의 버전 데이터에서 직접 값을 가져와 즉시 표시하며, 설정/프로필 전반에서 버전 표기가 일관되게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->