### PR TITLE
[Fix] 경기 시간이 10분 더해져서 보이는 문제 수정

### DIFF
--- a/Wable-iOS/Presentation/Overview/GameSchedule/View/GameScheduleListViewController.swift
+++ b/Wable-iOS/Presentation/Overview/GameSchedule/View/GameScheduleListViewController.swift
@@ -128,7 +128,7 @@ private extension GameScheduleListViewController {
         
         let gameScheduleCellRegistration = CellRegistration<GameScheduleCell, Game> { cell, indexPath, game in
             let gameTimeFormatter = DateFormatter().then {
-                $0.dateFormat = "HH:MM"
+                $0.dateFormat = "HH:mm"
             }
             
             let gameStatus = game.status ?? .progress


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 경기시간이 10분 더해져서 보이는 문제를 수정하였습니다.

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 수정 전 | <img src = "https://github.com/user-attachments/assets/405a291c-3556-43db-aa77-6c22b9fd9db1" width ="250"> |
| 수정 후 | <img src = "https://github.com/user-attachments/assets/25b2b281-ba81-4679-8ab1-f3a4514714a5" width ="250"> |



## 👀 리뷰어에게 전달할 사항
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 하드 코딩된 문자열을 사용하다 보니 이런 문제가 발생한 것 같아, 스프린트 후 사용되는 dateFormat에 대해 열거형을 구현하고 이를 통해 하드 코딩으로 인한 휴먼 에러를 방지해 보고자 노력해야겠다는 생각이 들었습니다.

## 🔗 연결된 이슈
- Resolved: #292
