### PR TITLE
[Refactor] OAuthProvider 및 AppCoordinator 진입점 함수 분리

### DIFF
--- a/Wable-iOS.xcodeproj/project.pbxproj
+++ b/Wable-iOS.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		DD514D102D8CA3780095021D /* AttributedString+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD514D0F2D8CA36D0095021D /* AttributedString+.swift */; };
 		DD51A44C2DD458A8004295B6 /* ProfileEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD51A44B2DD458A8004295B6 /* ProfileEditViewController.swift */; };
 		DD547AB92D7E43A600B8BA5A /* GhostButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD547AB82D7E439E00B8BA5A /* GhostButton.swift */; };
+		DD6DF3522ECC7D72005AC6A2 /* OAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6DF3512ECC7D6C005AC6A2 /* OAuthProvider.swift */; };
 		DD765D9A2D8746E30029A317 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD765D992D8746DD0029A317 /* LoginViewController.swift */; };
 		DD765D9D2D8747950029A317 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD765D9C2D8747900029A317 /* SplashViewController.swift */; };
 		DD7E79822DBFA48300570C23 /* UpdateUserBadgeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7E79812DBFA47000570C23 /* UpdateUserBadgeUseCase.swift */; };
@@ -595,6 +596,7 @@
 		DD514D0F2D8CA36D0095021D /* AttributedString+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+.swift"; sourceTree = "<group>"; };
 		DD51A44B2DD458A8004295B6 /* ProfileEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditViewController.swift; sourceTree = "<group>"; };
 		DD547AB82D7E439E00B8BA5A /* GhostButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostButton.swift; sourceTree = "<group>"; };
+		DD6DF3512ECC7D6C005AC6A2 /* OAuthProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthProvider.swift; sourceTree = "<group>"; };
 		DD765D992D8746DD0029A317 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		DD765D9C2D8747900029A317 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		DD7E79812DBFA47000570C23 /* UpdateUserBadgeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserBadgeUseCase.swift; sourceTree = "<group>"; };
@@ -1475,6 +1477,7 @@
 		DD87931D2D70452B001212AE /* OAuth */ = {
 			isa = PBXGroup;
 			children = (
+				DD6DF3512ECC7D6C005AC6A2 /* OAuthProvider.swift */,
 				DD29D8D62EC9F20300FDF889 /* OAuthRequestInterceptor.swift */,
 				DD29D8D82ECABD9A00FDF889 /* OAuthEventManager.swift */,
 			);
@@ -3295,6 +3298,7 @@
 				DD29682B2D6DAD0B00143851 /* CommentMapper.swift in Sources */,
 				DDCD66F32D7DF5AB00EF4C28 /* HomeViewController.swift in Sources */,
 				DD3935B62DDDB9F700B6CA94 /* MyProfileView.swift in Sources */,
+				DD6DF3522ECC7D72005AC6A2 /* OAuthProvider.swift in Sources */,
 				DE3CA28B2DD4697700BF5E87 /* RemoveUserSessionUseCase.swift in Sources */,
 				DD29682C2D6DAD0B00143851 /* ContentMapper.swift in Sources */,
 				DE83891B2D906C0C00C089E6 /* Types.swift in Sources */,

--- a/Wable-iOS/App/Coordinator/AppCoordinator.swift
+++ b/Wable-iOS/App/Coordinator/AppCoordinator.swift
@@ -29,14 +29,16 @@ final class AppCoordinator: Coordinator {
 
     // MARK: - Start
     
-    func start() { }
+    func start() {
+        showLogin()
+    }
 
     func start(hasActiveSession: Bool) {
         if hasActiveSession {
             updateFCMToken()
             showMain()
         } else {
-            showLogin()
+            start()
         }
     }
 

--- a/Wable-iOS/Infra/Local/UserDefaultsStorage.swift
+++ b/Wable-iOS/Infra/Local/UserDefaultsStorage.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct UserDefaultsStorage {
+@preconcurrency struct UserDefaultsStorage {
     private let userDefaults: UserDefaults
     private let jsonEncoder: JSONEncoder
     private let jsonDecoder: JSONDecoder

--- a/Wable-iOS/Infra/Network/APIProvider.swift
+++ b/Wable-iOS/Infra/Network/APIProvider.swift
@@ -22,11 +22,10 @@ final class APIProvider<Target: BaseTargetType>: MoyaProvider<Target> {
     
     init() {
         self.jsonDecoder = .init()
-
+        
         let interceptor = OAuthRequestInterceptor(
-            tokenStorage: TokenStorage(keyChainStorage: KeychainStorage()),
-            removeUserSessionUseCase: RemoveUserSessionUseCaseImpl(),
             logoutHandler: { OAuthEventManager.shared.tokenExpiredSubject.send() },
+            oauthProvider: OAuthProvider(),
             cancelBag: CancelBag()
         )
 

--- a/Wable-iOS/Infra/Network/OAuth/OAuthProvider.swift
+++ b/Wable-iOS/Infra/Network/OAuth/OAuthProvider.swift
@@ -1,0 +1,85 @@
+//
+//  OAuthProvider.swift
+//  Wable-iOS
+//
+//  Created by Youjin Lee on 11/18/25.
+//
+
+import Combine
+import Foundation
+
+@preconcurrency import Moya
+
+public final class OAuthProvider: Sendable {
+    
+    // MARK: - Property
+    
+    private let tokenRefreshProvider: MoyaProvider<LoginTargetType>
+    private let userSessionStorage: UserDefaultsStorage
+    private let tokenStorage: TokenStorage
+    private let jsonDecoder: JSONDecoder
+    private let cancelBag: CancelBag
+    
+    // MARK: - LifeCycle
+    
+    init(
+        tokenRefreshProvider: MoyaProvider<LoginTargetType> = MoyaProvider<LoginTargetType>(
+            plugins: [MoyaLoggingPlugin()]
+        ),
+        userSessionStorage: UserDefaultsStorage = UserDefaultsStorage(),
+        tokenStorage: TokenStorage = TokenStorage(keyChainStorage: KeychainStorage()),
+        jsonDecoder: JSONDecoder = JSONDecoder(),
+        cancelBag: CancelBag = CancelBag()
+    ) {
+        self.tokenRefreshProvider = tokenRefreshProvider
+        self.userSessionStorage = userSessionStorage
+        self.tokenStorage = tokenStorage
+        self.jsonDecoder = jsonDecoder
+        self.cancelBag = cancelBag
+    }
+}
+
+// MARK: - Internal Helper
+
+extension OAuthProvider {
+    func loadToken(for tokenType: TokenStorage.TokenType) throws -> String {
+        return try tokenStorage.load(tokenType)
+    }
+    
+    func saveToken(token: Token) throws {
+        try tokenStorage.save(token.accessToken, for: .wableAccessToken)
+        try tokenStorage.save(token.refreshToken, for: .wableRefreshToken)
+    }
+
+    func refreshToken() -> AnyPublisher<Token, WableError> {
+        return tokenRefreshProvider.requestPublisher(.fetchTokenStatus)
+            .map { $0.data }
+            .decode(type: BaseResponse<DTO.Response.UpdateToken>.self, decoder: jsonDecoder)
+            .tryMap { response -> DTO.Response.UpdateToken in
+                guard response.success else { throw WableError.signinRequired }
+                guard let data = response.data else { throw WableError.unknownError }
+                return data
+            }
+            .map(LoginMapper.toDomain)
+            .mapError { ($0 as? WableError) ?? .unknownError }
+            .eraseToAnyPublisher()
+    }
+    
+    func removeSession() {
+        do {
+            try tokenStorage.delete(.wableAccessToken)
+            try tokenStorage.delete(.wableRefreshToken)
+            try userSessionStorage.removeValue(for: Constants.activeUserID)
+        } catch {
+            WableLogger.log("세션 삭제 실패: \(error.localizedDescription)", for: .error)
+        }
+    }
+}
+
+// MARK: - Constant
+
+private extension OAuthProvider {
+    enum Constants {
+        static let activeUserID = "activeID"
+    }
+}

--- a/Wable-iOS/Infra/Network/OAuth/OAuthRequestInterceptor.swift
+++ b/Wable-iOS/Infra/Network/OAuth/OAuthRequestInterceptor.swift
@@ -14,14 +14,14 @@ final class OAuthRequestInterceptor: RequestInterceptor {
 
     // MARK: - Property
     
-    private let logoutHandler: (@Sendable () -> Void)?
+    private let logoutHandler: (@Sendable () -> Void)
     private let oauthProvider: OAuthProvider
     private let cancelBag: CancelBag
 
     // MARK: - LifeCycle
     
     init(
-        logoutHandler: (@Sendable () -> Void)?,
+        logoutHandler: @escaping (@Sendable () -> Void),
         oauthProvider: OAuthProvider,
         cancelBag: CancelBag
     ) {
@@ -146,7 +146,7 @@ private extension OAuthRequestInterceptor {
 
             if error == .signinRequired {
                 oauthProvider.removeSession()
-                logoutHandler?()
+                logoutHandler()
             }
             completion(.doNotRetry)
         }
@@ -160,7 +160,7 @@ private extension OAuthRequestInterceptor {
         } catch {
             WableLogger.log("토큰 저장 실패: \(error)", for: .error)
             oauthProvider.removeSession()
-            logoutHandler?()
+            logoutHandler()
             completion(.doNotRetry)
         }
     }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

# 👻 *PULL REQUEST*

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- `OAuthProvider`에 토큰 및 세션 처리 관련 로직을 추가해 `Interceptor`의 책임을 분리했어요.
- `AppCoordinator`의 진입점을 `start()`와 `start(hasActiveSession: Bool)`로 분리했어요.
+ 어제 회의에서 나왔던 부분 반영 PR입니다! (깜빡하고 머지해버렸어요... 탄천 두다이브!)

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### `Interceptor` 책임 분리를 위한 `OAuthProvider` 구현
- 회의 때 이야기했던 것처럼 인터셉터의 책임 분리가 필요하다는 판단 하에 일차적으로 `OAuthProvider`를 구현했습니다.
- 이후 회의 결과에 따라 해당 로직을 이동하거나 UseCase로 편입해 수행할 수 있도록 처리하면 좋을 것 같습니다 ~!

### 빈 함수 생성을 막기 위한 `start(hasActiveSession: Bool)` 함수의 로직 분리
- 회의 때 말씀해주셨던 `start()` 생성자의 빈 구현을 막기 위해 `start(hasActiveSession: Bool)` 함수 내에서 if-else 조건 처리를 통해 `hasActiveSession`이 `false`일 경우 `start()` 생성자를 호출하고, 해당 함수 내에서 `showLogin()`을 호출할 수 있도록 구현했습니다.

```Swift
    func start() {
        showLogin()
    }

    func start(hasActiveSession: Bool) {
        if hasActiveSession {
            updateFCMToken()
            showMain()
        } else {
            start()
        }
    }
```

## 🔗 연결된 이슈
- Resolved: #315 
